### PR TITLE
Update alpine container base image to 3.9

### DIFF
--- a/build/package/Dockerfile.run
+++ b/build/package/Dockerfile.run
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.9
 MAINTAINER "Stakater Team"
 
 RUN apk add --update ca-certificates


### PR DESCRIPTION
Earlier this month a potential security vulnerability in Alpine was found (see [CVE-2019-5021](https://www.alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html) for more details). Even when this currently doesn't seem to affect your image, it would be cool if your Docker images would be using an up-to-date version of alpine as version 3.4 is EOL anyway. This PR proposes an update to 3.9. 