### PR TITLE
Fix issue with readOnlyRootFilesystem and statefulsets permissions

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
       - secrets
       - configmaps
     verbs:
@@ -23,12 +23,21 @@ rules:
       - get
       - watch
   - apiGroups:
-      - "extensions"
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -70,6 +70,11 @@ spec:
         image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
         imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
         name: {{ template "reloader-name" . }}
+      {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+        volumeMounts:
+          - mountPath: /tmp/
+            name: tmp-volume
+      {{- end }}
       {{- if .Values.reloader.custom_annotations }}
         args:
           {{- if .Values.reloader.custom_annotations.configmap }}
@@ -86,3 +91,8 @@ spec:
           {{- end }}
       {{- end }}
       serviceAccountName: {{ template "reloader-serviceAccountName" . }}
+    {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+      volumes:
+        - emptyDir: {}
+          name: tmp-volume
+    {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
       - secrets
       - configmaps
     verbs:
@@ -23,12 +23,21 @@ rules:
       - get
       - watch
   - apiGroups:
-      - "extensions"
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -5,6 +5,8 @@ kubernetes:
 
 reloader:
   watchGlobally: true
+  # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
+  readOnlyRootFileSystem: false
   matchLabels: {}
   deployment:
     annotations: {}
@@ -40,4 +42,4 @@ reloader:
   #   custom_annotations:
   #     configmap: "my.company.com/configmap"
   #     secret: "my.company.com/secret"
-  custom_annotations: {} 
+  custom_annotations: {}

--- a/deployments/kubernetes/manifests/clusterrole.yaml
+++ b/deployments/kubernetes/manifests/clusterrole.yaml
@@ -14,7 +14,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
       - secrets
       - configmaps
     verbs:
@@ -22,12 +22,21 @@ rules:
       - get
       - watch
   - apiGroups:
-      - "extensions"
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/deployments/kubernetes/reloader.yaml
+++ b/deployments/kubernetes/reloader.yaml
@@ -15,7 +15,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v0.0.29
-    
+
   name: reloader
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         group: com.stakater.platform
         provider: stakater
         version: v0.0.29
-        
+
     spec:
       containers:
       - env:
@@ -59,7 +59,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
       - secrets
       - configmaps
     verbs:
@@ -67,12 +67,21 @@ rules:
       - get
       - watch
   - apiGroups:
-      - "extensions"
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -5,6 +5,8 @@ kubernetes:
 
 reloader:
   watchGlobally: true
+  # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
+  readOnlyRootFileSystem: false
   matchLabels: {}
   deployment:
     annotations: {}
@@ -40,4 +42,4 @@ reloader:
   #   custom_annotations:
   #     configmap: "my.company.com/configmap"
   #     secret: "my.company.com/secret"
-  custom_annotations: {} 
+  custom_annotations: {}


### PR DESCRIPTION
### readOnlyRootFilesystem

We use a pod security policy that forbid pods from writing to the container filesystem. This fix adds an optional parameter `reloader.readOnlyRootFileSystem` that you can set to `true` to mount` /tmp` to an emptyDir to make it work.

Example of error we get without fix, right before the pod dies:

`log: exiting because of error: log: cannot create log: open /tmp/Reloader.reloader-745c4cf859-fk96s.unknownuser.log.ERROR.20190606-101934.1: read-only file system`

### statefulsets permission

As far as I could figure out, statefulsets does not use the "extensions" apiGroup, and our users also do not have that permission. This fix splits role and clusterrole permissions for "apps" and "extensions" apiGroup so that only applicable resources are used for each apiGroup.

Let me know if I'm wrong.