### PR TITLE
fix-dnsPolicy-issue

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,11 +1,11 @@
 package: github.com/stakater/Reloader
 import:
 - package: k8s.io/api
-  version: kubernetes-1.8.0
+  version: kubernetes-1.10.0
 - package: k8s.io/apimachinery
-  version: kubernetes-1.8.0
+  version: kubernetes-1.10.0
 - package: k8s.io/client-go
-  version: 5.0.0
+  version: 6.0.0
 - package: github.com/spf13/cobra
   version: 0.0.3
 - package: github.com/spf13/pflag


### PR DESCRIPTION
bump package version in glide.yaml file. k8s.io/api version 1.8.0 to 1.10.0 and client go version 5.0.0 to 6.0.0.

close #70 