### PR TITLE
JSON logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 
 `Note`: At one time only one of these resource can be ignored, trying to do it will cause error in helm template compilation.
 
+You can also set the log format of Reloader to json by setting `logFormat` to `json` in values.yaml and apply the chart
+
 ## Help
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ spec:
 - you may override the secret annotation with the `--secret-annotation` flag
 - you may want to prevent watching certain namespaces with the `--namespaces-to-ignore` flag
 - you may want to prevent watching certain resources with the `--resources-to-ignore` flag
+- you can configure logging in JSON format with the `--log-format=json` option
 
 ## Deploying to Kubernetes
 

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -92,6 +92,9 @@ spec:
             name: tmp-volume
       {{- end }}
         args:
+          {{- if .Values.reloader.logFormat }}
+          - "--log-format={{ .Values.reloader.logFormat }}"
+          {{- end }}
           {{- if .Values.reloader.ignoreSecrets }}
           - "--resources-to-ignore=secrets"
           {{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -12,6 +12,7 @@ reloader:
   isOpenshift: false
   ignoreSecrets: false
   ignoreConfigMaps: false
+  logFormat: "" #json
   watchGlobally: true
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
   readOnlyRootFileSystem: false

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -12,6 +12,7 @@ reloader:
   isOpenshift: false
   ignoreSecrets: false
   ignoreConfigMaps: false
+  logFormat: "" #json
   watchGlobally: true
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
   readOnlyRootFileSystem: false

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -7,4 +7,6 @@ var (
 	SecretUpdateOnChangeAnnotation = "secret.reloader.stakater.com/reload"
 	// ReloaderAutoAnnotation is an annotation to detect changes in secrets
 	ReloaderAutoAnnotation = "reloader.stakater.com/auto"
+	// LogFormat is the log format to use (json, or empty string for default)
+	LogFormat = ""
 )


### PR DESCRIPTION
Logrus supports JSON formatted logs, we parse all logs we ingest via fluentd as JSON so this would be very useful.