### PR TITLE
Remove redundant namePrefix from kustomization.yaml sample on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ You can write your own `kustomization.yaml` using ours as a 'base' and write pat
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namePrefix: reloader-
-
 bases:
   - https://github.com/stakater/Reloader/deployments/kubernetes
 


### PR DESCRIPTION
Kubernetes resources generated from `kustomization.yaml` sample on README.md have names with redundant `reloader-` prefix like `reloader-reloader-reloader`.

I think it's a little too redundant, so remove namePrefix from `kustomization.yaml` sample.

<details>
<summary>result of `kubectl kustomize` before this fix</summary>

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader-reloader
  namespace: reloader
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRole
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader-reloader-role
  namespace: default
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  - configmaps
  verbs:
  - list
  - get
  - watch
- apiGroups:
  - apps
  resources:
  - deployments
  - daemonsets
  - statefulsets
  verbs:
  - list
  - get
  - update
  - patch
- apiGroups:
  - extensions
  resources:
  - deployments
  - daemonsets
  verbs:
  - list
  - get
  - update
  - patch
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRoleBinding
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader-reloader-role-binding
  namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: reloader-reloader-reloader-role
subjects:
- kind: ServiceAccount
  name: reloader-reloader-reloader
  namespace: reloader
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    group: com.stakater.platform
    heritage: Tiller
    provider: stakater
    release: reloader
    version: v0.0.53
  name: reloader-reloader-reloader
  namespace: reloader
spec:
  replicas: 1
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: reloader-reloader
      release: reloader
  template:
    metadata:
      labels:
        app: reloader-reloader
        chart: reloader-v0.0.53
        group: com.stakater.platform
        heritage: Tiller
        provider: stakater
        release: reloader
        version: v0.0.53
    spec:
      containers:
      - args: null
        env: null
        image: stakater/reloader:v0.0.53
        imagePullPolicy: IfNotPresent
        name: reloader-reloader
      serviceAccountName: reloader-reloader-reloader
```

</details>

<details>
<summary>result of `kubectl kustomize` after this fix</summary>

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader
  namespace: reloader
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRole
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader-role
  namespace: default
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  - configmaps
  verbs:
  - list
  - get
  - watch
- apiGroups:
  - apps
  resources:
  - deployments
  - daemonsets
  - statefulsets
  verbs:
  - list
  - get
  - update
  - patch
- apiGroups:
  - extensions
  resources:
  - deployments
  - daemonsets
  verbs:
  - list
  - get
  - update
  - patch
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRoleBinding
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    heritage: Tiller
    release: reloader
  name: reloader-reloader-role-binding
  namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: reloader-reloader-role
subjects:
- kind: ServiceAccount
  name: reloader-reloader
  namespace: reloader
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: reloader-reloader
    chart: reloader-v0.0.53
    group: com.stakater.platform
    heritage: Tiller
    provider: stakater
    release: reloader
    version: v0.0.53
  name: reloader-reloader
  namespace: reloader
spec:
  replicas: 1
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: reloader-reloader
      release: reloader
  template:
    metadata:
      labels:
        app: reloader-reloader
        chart: reloader-v0.0.53
        group: com.stakater.platform
        heritage: Tiller
        provider: stakater
        release: reloader
        version: v0.0.53
    spec:
      containers:
      - args: null
        env: null
        image: stakater/reloader:v0.0.53
        imagePullPolicy: IfNotPresent
        name: reloader-reloader
      serviceAccountName: reloader-reloader
```
</details>