### PR TITLE
Refactor Dockerfile

### DIFF
--- a/build/package/Dockerfile.build
+++ b/build/package/Dockerfile.build
@@ -1,7 +1,5 @@
-FROM golang:1.13.1-alpine
+FROM golang:1.13.9-alpine
 LABEL maintainer "Stakater Team"
-
-RUN apk update
 
 RUN apk -v --update \
     --no-cache \

--- a/build/package/Dockerfile.build
+++ b/build/package/Dockerfile.build
@@ -1,18 +1,23 @@
 FROM golang:1.13.1-alpine
-MAINTAINER "Stakater Team"
+LABEL maintainer "Stakater Team"
 
 RUN apk update
 
 RUN apk -v --update \
-    add git build-base && \
-    rm -rf /var/cache/apk/* && \
-    mkdir -p "$GOPATH/src/github.com/stakater/Reloader"
+    --no-cache \
+    add git build-base
 
-ADD . "$GOPATH/src/github.com/stakater/Reloader"
+WORKDIR "$GOPATH/src/github.com/stakater/Reloader"
 
-RUN cd "$GOPATH/src/github.com/stakater/Reloader" && \
-    go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo --ldflags="-s" -o /Reloader
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
+RUN go build -a --installsuffix cgo --ldflags="-s" -o /Reloader
 
 COPY build/package/Dockerfile.run /
 

--- a/build/package/Dockerfile.run
+++ b/build/package/Dockerfile.run
@@ -1,7 +1,7 @@
-FROM alpine:3.9
-MAINTAINER "Stakater Team"
+FROM alpine:3.11
+LABEL maintainer "Stakater Team"
 
-RUN apk add --update ca-certificates
+RUN apk add --update --no-cache ca-certificates
 
 COPY Reloader /bin/Reloader
 


### PR DESCRIPTION
## What I did in this PR
1. MAINTAINER is deprecated so use LABEL maintainer instead
2. `rm -rf /var/cache/apk/*` after apk add is deprecated and you only need to add --no-cache option since Alpine 3.3
3. mkdir -p and cd makes no sense in Dockerfile and let's just use WORKDIR which does the both
4. `COPY go.mod go.sum ./` separately for better build caching
5. Use ENV for go build for better maintainability
6. Alpine linux 3.9 -> 3.11

## What I can do but need your opinion
1. Use [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) which makes the Dockerfile into single file from two separated for faster & simpler build process
2. Update golang version
3. remove `RUN apk update` as it's not a usual manner for a container as it can unexpectedly break dependency