### PR TITLE
add metrics endpoints to kubernetes specs

### DIFF
--- a/build/package/Dockerfile.run
+++ b/build/package/Dockerfile.run
@@ -8,4 +8,7 @@ COPY Reloader /bin/Reloader
 # On alpine 'nobody' has uid 65534
 USER 65534
 
+# Port for metrics and probes
+EXPOSE 9090
+
 ENTRYPOINT ["/bin/Reloader"]

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -89,6 +89,19 @@ spec:
               fieldPath: metadata.namespace
       {{- end }}
       {{- end }}
+
+        ports:
+        - name: http
+          containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+
       {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
         volumeMounts:
           - mountPath: /tmp/

--- a/deployments/kubernetes/chart/reloader/templates/service.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/service.yaml
@@ -22,5 +22,8 @@ spec:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   ports:
-{{ toYaml .Values.reloader.service.ports | indent 4 }}
+  - port: {{ .Values.reloader.service.port }}
+    name: http
+    protocol: TCP
+    targetPort: http
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -81,11 +81,7 @@ reloader:
   service: {}
     # labels: {}
     # annotations: {}
-    # ports:
-    # - port: 9090
-    #   name: http
-    #   protocol: TCP
-    #   targetPort: 9090
+    # port: 9090
 
   rbac:
     enabled: true

--- a/deployments/kubernetes/manifests/deployment.yaml
+++ b/deployments/kubernetes/manifests/deployment.yaml
@@ -41,6 +41,17 @@ spec:
       - image: "stakater/reloader:v0.0.73"
         imagePullPolicy: IfNotPresent
         name: reloader-reloader
+        ports:
+        - name: http
+          containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
       securityContext: 
         runAsNonRoot: true
         runAsUser: 65534

--- a/deployments/kubernetes/reloader.yaml
+++ b/deployments/kubernetes/reloader.yaml
@@ -116,6 +116,18 @@ spec:
       - image: "stakater/reloader:v0.0.73"
         imagePullPolicy: IfNotPresent
         name: reloader-reloader
+
+        ports:
+        - name: http
+          containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
       securityContext: 
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
Added:

* EXPOSE directive to Dockerfile
* ports to deployment
* probes
* service with metrics endpoint

Thus, beginners will see that there are some metrics