### PR TITLE
Include data from ConfigMap.BinaryData when calculating SHA

### DIFF
--- a/internal/pkg/handler/update.go
+++ b/internal/pkg/handler/update.go
@@ -33,7 +33,7 @@ func (r ResourceUpdatedHandler) GetConfig() (util.Config, string) {
 	var oldSHAData string
 	var config util.Config
 	if _, ok := r.Resource.(*v1.ConfigMap); ok {
-		oldSHAData = util.GetSHAfromConfigmap(r.OldResource.(*v1.ConfigMap).Data)
+		oldSHAData = util.GetSHAfromConfigmap(r.OldResource.(*v1.ConfigMap))
 		config = util.GetConfigmapConfig(r.Resource.(*v1.ConfigMap))
 	} else if _, ok := r.Resource.(*v1.Secret); ok {
 		oldSHAData = util.GetSHAfromSecret(r.OldResource.(*v1.Secret).Data)

--- a/internal/pkg/util/config.go
+++ b/internal/pkg/util/config.go
@@ -23,7 +23,7 @@ func GetConfigmapConfig(configmap *v1.ConfigMap) Config {
 		ResourceName:        configmap.Name,
 		ResourceAnnotations: configmap.Annotations,
 		Annotation:          options.ConfigmapUpdateOnChangeAnnotation,
-		SHAValue:            GetSHAfromConfigmap(configmap.Data),
+		SHAValue:            GetSHAfromConfigmap(configmap),
 		Type:                constants.ConfigmapEnvVarPostfix,
 	}
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -2,10 +2,12 @@ package util
 
 import (
 	"bytes"
+	"encoding/base64"
 	"sort"
 	"strings"
 
 	"github.com/stakater/Reloader/internal/pkg/crypto"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ConvertToEnvVarName converts the given text into a usable env var
@@ -29,10 +31,13 @@ func ConvertToEnvVarName(text string) string {
 	return buffer.String()
 }
 
-func GetSHAfromConfigmap(data map[string]string) string {
+func GetSHAfromConfigmap(configmap *v1.ConfigMap) string {
 	values := []string{}
-	for k, v := range data {
+	for k, v := range configmap.Data {
 		values = append(values, k+"="+v)
+	}
+	for k, v := range configmap.BinaryData {
+		values = append(values, k+"="+base64.StdEncoding.EncodeToString(v))
 	}
 	sort.Strings(values)
 	return crypto.GenerateSHA(strings.Join(values, ";"))

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestConvertToEnvVarName(t *testing.T) {
@@ -9,5 +11,37 @@ func TestConvertToEnvVarName(t *testing.T) {
 	envVar := ConvertToEnvVarName(data)
 	if envVar != "WWW_STAKATER_COM" {
 		t.Errorf("Failed to convert data into environment variable")
+	}
+}
+
+func TestGetHashFromConfigMap(t *testing.T) {
+	data := map[*v1.ConfigMap]string{
+		{
+			Data: map[string]string{"test": "test"},
+		}: "Only Data",
+		{
+			Data:       map[string]string{"test": "test"},
+			BinaryData: map[string][]byte{"bintest": []byte("test")},
+		}: "Both Data and BinaryData",
+		{
+			BinaryData: map[string][]byte{"bintest": []byte("test")},
+		}: "Only BinaryData",
+	}
+	converted := map[string]string{}
+	for cm, cmName := range data {
+		converted[cmName] = GetSHAfromConfigmap(cm)
+	}
+
+	// Test that the has for each configmap is really unique
+	for cmName, cmHash := range converted {
+		count := 0
+		for _, cmHash2 := range converted {
+			if cmHash == cmHash2 {
+				count++
+			}
+		}
+		if count > 1 {
+			t.Errorf("Found duplicate hashes for %v", cmName)
+		}
 	}
 }


### PR DESCRIPTION
Include values from ConfigMap.BinaryData when calculating the SHA so that changes there will also trigger a reload.