### PR TITLE
Add fullnameOverride to helm chart

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: v0.0.65
+version: v0.0.66
 appVersion: v0.0.65
 keywords:
   - Reloader

--- a/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
+++ b/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
@@ -12,8 +12,12 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "reloader-fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "reloader-labels.chart" -}}


### PR DESCRIPTION
I'd like to be able to install Reloader into my kubernetes cluster with custom name, e.g. `name: stakater-reloader`.  
Without these changes I get `name: stakater-reloader-reloader`