### PR TITLE
Add okteto manifest to develop Reloader directly on Kubernetes

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,3 @@
+.git
+Reloader
+__debug_bin

--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ Please use the [issue tracker](https://github.com/stakater/Reloader/issues) to r
 
 ### Developing
 
+1. Deploy Reloader.
+2. Run `okteto up` to activate your development container.
+3. `make build`.
+4. `./Reloader`
+
 PRs are welcome. In general, we follow the "fork-and-pull" Git workflow.
 
 1.  **Fork** the repo on GitHub

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,14 @@
+name: reloader-reloader
+image: okteto/golang:1
+command: bash
+securityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+volumes:
+  - /go/pkg/
+  - /root/.cache/go-build/
+sync:
+  - .:/app
+forward:
+  - 2345:2345


### PR DESCRIPTION
Okteto lets you develop directly on the reloader deployment without building docker images to test each change