### PR TITLE
Trim spaces in annotation list

### DIFF
--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -116,7 +116,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 		if result != constants.Updated && annotationValue != "" {
 			values := strings.Split(annotationValue, ",")
 			for _, value := range values {
-				value = strings.Trim(value, " \n")
+				value = strings.Trim(value, " ")
 				if value == config.ResourceName {
 					result = updateContainers(upgradeFuncs, i, config, false)
 					if result == constants.Updated {

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -116,6 +116,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 		if result != constants.Updated && annotationValue != "" {
 			values := strings.Split(annotationValue, ",")
 			for _, value := range values {
+				value = strings.Trim(value, " \n")
 				if value == config.ResourceName {
 					result = updateContainers(upgradeFuncs, i, config, false)
 					if result == constants.Updated {

--- a/internal/pkg/testutil/kube.go
+++ b/internal/pkg/testutil/kube.go
@@ -821,6 +821,7 @@ func VerifyResourceUpdate(clients kube.Clients, config util.Config, envVarPostfi
 		} else if annotationValue != "" {
 			values := strings.Split(annotationValue, ",")
 			for _, value := range values {
+				value = strings.Trim(value, " ")
 				if value == config.ResourceName {
 					matches = true
 					break


### PR DESCRIPTION
Our users often provide their annotation list about secrets to watch in a comma AND space separated list, like this:
"secret1, secret2, secret3". This causes Reloader to pick up on only the first secret, and ignoring changes on the rest. Since this is a very natural expression of lists and aligns with the format used in  other annotation lists, I would like to accommodate this. 

I bumped into some problems in our systems because of the extra spaces, this is why I am posting this PR. I am happy to answer any questions.