### PR TITLE
Add Helm chart support for --namespaces-to-ignore flag

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           - mountPath: /tmp/
             name: tmp-volume
       {{- end }}
-      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (eq .Values.reloader.ignoreConfigMaps true) (.Values.reloader.custom_annotations) }}
+      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) }}
         args:
           {{- if .Values.reloader.logFormat }}
           - "--log-format={{ .Values.reloader.logFormat }}"
@@ -101,8 +101,11 @@ spec:
           {{- if .Values.reloader.ignoreSecrets }}
           - "--resources-to-ignore=secrets"
           {{- end }}
-          {{- if eq .Values.reloader.ignoreConfigMaps true }}
+          {{- if .Values.reloader.ignoreConfigMaps }}
           - "--resources-to-ignore=configMaps"
+          {{- end }}
+          {{- if .Values.reloader.ignoreNamespaces }}
+          - "--namespaces-to-ignore={{ .Values.reloader.ignoreNamespaces }}"
           {{- end }}
 
           {{- if .Values.reloader.custom_annotations }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -12,6 +12,7 @@ reloader:
   isOpenshift: false
   ignoreSecrets: false
   ignoreConfigMaps: false
+  ignoreNamespaces: "" # Comma separated list of namespaces to ignore
   logFormat: "" #json
   watchGlobally: true
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -12,6 +12,7 @@ reloader:
   isOpenshift: false
   ignoreSecrets: false
   ignoreConfigMaps: false
+  ignoreNamespaces: "" # Comma separated list of namespaces to ignore
   logFormat: "" #json
   watchGlobally: true
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem


### PR DESCRIPTION
Would be nice to offer, since the other ignore-related flags are already supported in Helm.