### PR TITLE
Add optional ServiceMonitor object to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 
 You can also set the log format of Reloader to json by setting `logFormat` to `json` in values.yaml and apply the chart
 
+You can enable to scrape Reloader's Prometheus metrics by setting `serviceMonitor.enabled`  to `true` in values.yaml file.
+
 ## Help
 
 ### Documentation

--- a/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.reloader.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.serviceMonitor.labels }}
+{{ toYaml .Values.reloader.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}
+{{- if .Values.reloader.serviceMonitor.namespace }}
+  namespace: {{ .Values.reloader.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: http
+    path: "/metrics"
+{{- if .Values.reloader.serviceMonitor.interval }}
+    interval: {{ .Values.reloader.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.reloader.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.reloader.serviceMonitor.timeout }}
+{{- end }}
+  jobLabel: {{ template "reloader-fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{ include "reloader-labels.chart" . | nindent 6 }}
+{{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -104,3 +104,14 @@ reloader:
   #     configmap: "my.company.com/configmap"
   #     secret: "my.company.com/secret"
   custom_annotations: {}
+  serviceMonitor:
+    # enabling this requires service to be enabled as well, or no endpoints will be found
+    enabled: false
+    # Set the namespace the ServiceMonitor should be deployed
+    # namespace: monitoring
+    # Set how frequently Prometheus should scrape
+    # interval: 30s
+    # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+    # labels:
+    # Set timeout for scrape
+    # timeout: 10s


### PR DESCRIPTION
This pull request would add support in the Helm chart to opt-in to creating a `ServiceMonitor` configured to scrape Reloader's Prometheus metrics. The `ServiceMonitor` is a CRD installed by [the Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) project, which helps automate Prometheus configuration. While fairly popular, I know that most users will not have that operator installed, and you probably don't want to support everyone's pet CRDs in your project's chart. So I'll understand if you'd rather not merge this PR in.

But for people who do have the Prometheus operator installed, this makes it trivial to start monitoring Reloader. I borrowed this template from another chart that I considered well implemented, [the `postgres-prometheus-exporter`](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml) and modified it slightly to match Reloader's configuration. I have verified that there are no changes in the default chart installation, and it will only create the CRD if you have opted in.

Whether you choose to merge this in or not, thank you for the project, it's really useful! I get at least one request a month for help from someone who modified a Secret and forgot to restart pods, so this is going to save everyone some time. Thanks!