### PR TITLE
Enable support for multi-arch container image build/ publish: linux/arm, linux/arm64 and linux/amd64.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 # note: call scripts from /scripts
 
-.PHONY: default build builder-image binary-image test stop clean-images clean push apply deploy
+.PHONY: default build builder-image binary-image test stop clean-images clean push apply deploy release release-all manifest push clean-image
 
-BUILDER ?= reloader-builder
+OS ?= linux
+ARCH ?= ???
+ALL_ARCH ?= arm64 arm amd64
+
+BUILDER ?= reloader-builder-${ARCH}
 BINARY ?= Reloader
 DOCKER_IMAGE ?= stakater/reloader
 # Default value "dev"
-DOCKER_TAG ?= 1.0.0
-REPOSITORY = ${DOCKER_IMAGE}:${DOCKER_TAG}
+TAG ?= v0.0.75.0
+REPOSITORY_GENERIC = ${DOCKER_IMAGE}:${TAG}
+REPOSITORY_ARCH = ${DOCKER_IMAGE}:${TAG}-${ARCH}
 
 VERSION=$(shell cat .version)
 BUILD=
@@ -25,10 +30,35 @@ build:
 	"$(GOCMD)" build ${GOFLAGS} ${LDFLAGS} -o "${BINARY}"
 
 builder-image:
-	@docker build --network host -t "${BUILDER}" -f build/package/Dockerfile.build .
+	docker buildx build --platform ${OS}/${ARCH} --build-arg GOARCH=$(ARCH) -t "${BUILDER}" --load -f build/package/Dockerfile.build .
+
+reloader-${ARCH}.tar:
+	docker buildx build --platform ${OS}/${ARCH} --build-arg GOARCH=$(ARCH) -t "${BUILDER}" --load -f build/package/Dockerfile.build .
+	docker run --platform ${OS}/${ARCH} --rm "${BUILDER}" > reloader-${ARCH}.tar
 
 binary-image: builder-image
-	@docker run --network host --rm "${BUILDER}" | docker build --network host -t "${REPOSITORY}" -f Dockerfile.run -
+	cat reloader-${ARCH}.tar | docker buildx build --platform ${OS}/${ARCH} -t "${REPOSITORY_ARCH}"  --load -f Dockerfile.run -
+
+push:
+	docker push ${REPOSITORY_ARCH}
+
+release:  binary-image push manifest
+
+release-all:
+	-rm -rf ~/.docker/manifests/*
+	# Make arch-specific release
+	@for arch in $(ALL_ARCH) ; do \
+		echo Make release: $$arch ; \
+		make release ARCH=$$arch ; \
+	done
+
+	set -e
+	docker manifest push --purge $(REPOSITORY_GENERIC)
+
+manifest:
+	set -e
+	docker manifest create -a $(REPOSITORY_GENERIC) $(REPOSITORY_ARCH)
+	docker manifest annotate --arch $(ARCH) $(REPOSITORY_GENERIC)  $(REPOSITORY_ARCH)
 
 test:
 	"$(GOCMD)" test -timeout 1800s -v ./...
@@ -37,13 +67,21 @@ stop:
 	@docker stop "${BINARY}"
 
 clean-images: stop
-	@docker rmi "${BUILDER}" "${BINARY}"
+	-docker rmi "${BINARY}"
+	@for arch in $(ALL_ARCH) ; do \
+		echo Clean image: $$arch ; \
+		make clean-image ARCH=$$arch ; \
+	done
+	-docker rmi "${REPOSITORY_GENERIC}"
+
+clean-image:
+	-docker rmi "${BUILDER}"
+	-docker rmi "${REPOSITORY_ARCH}"
+	-rm -rf ~/.docker/manifests/*
 
 clean:
 	"$(GOCMD)" clean -i
-
-push: ## push the latest Docker image to DockerHub
-	docker push $(REPOSITORY)
+	-rm -rf reloader-*.tar
 
 apply:
 	kubectl apply -f deployments/manifests/ -n temp-reloader

--- a/build/package/Dockerfile.build
+++ b/build/package/Dockerfile.build
@@ -1,6 +1,8 @@
 FROM golang:1.13.9-alpine
 LABEL maintainer "Stakater Team"
 
+ARG GOARCH=amd64
+
 RUN apk -v --update \
     --no-cache \
     add git build-base
@@ -13,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH
 
 RUN go build -a --installsuffix cgo --ldflags="-s" -o /Reloader
 

--- a/docs/Container Build.md
+++ b/docs/Container Build.md
@@ -1,0 +1,41 @@
+
+# Container Build
+> **WARNING:** As a user of Reloader there is no need to build containers, these are freely available here: https://hub.docker.com/r/stakater/reloader/
+
+Multi-architecture approach is based on original work by @mdh02038: https://github.com/mdh02038/Reloader
+
+Images tested on linux/arm, linux/arm64 and linux/amd64.
+
+# Install Pre-Reqs
+The build environment requires the following packages (tested on Ubuntu 20.04):
+* golang
+* make
+* qemu (for arm, arm64 etc. emulation)
+* binfmt-support
+* Docker engine
+
+## Docker
+Follow instructions here: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+
+Once installed, enable the experimental CLI:
+```
+export DOCKER_CLI_EXPERIMENTAL=enabled
+```
+Login, to enable publishing of packages:
+```
+sudo docker login
+```
+## Remaining Pre-Reqs
+Remaining Pre-Reqs can be installed via:
+```
+sudo apt install golang make qemu-user-static binfmt-support -y
+```
+
+# Publish Multi-Architecture Image
+To build/ publish multi-arch Docker images clone repository and execute from repository root:
+```
+sudo make release-all
+```
+
+# Additional Links/ Info
+* *https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408


### PR DESCRIPTION
I noticed that the current container images for Reloader only support linux/amd64. This PR adds multi-arch support to container build and publish leveraging `docker buildx` 

Based upon @mdh02038 original work available here: https://github.com/mdh02038/Reloader/

Example linux/arm, linux/arm64 and linux/amd64 container images available on Docker Hub: `coldfire84/reloader:v0.0.75.0`

![image](https://user-images.githubusercontent.com/22571742/102689669-e0d95880-41f7-11eb-8523-d0c234e316c7.png)

Have included documentation on build environment setup under /docs.