### PR TITLE
[helm chart] Check api version availability instead of using legacy value

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Reloader can watch changes in `ConfigMap` and `Secret` and do rolling upgrades o
 ## Compatibility
 
 Reloader is compatible with kubernetes >= 1.9
-The `apiVersion: rbac.authorization.k8s.io/v1beta1` is depreciated since kubernetes = 1.17. To run it with older versions, please use the chart parameter `reloader.legacy.rbac=true`
 
 ## How to use Reloader
 
@@ -200,12 +199,6 @@ helm repo add stakater https://stakater.github.io/stakater-charts
 helm repo update
 
 helm install stakater/reloader # For helm3 add --generate-name flag or set the release name
-```
-
-**Note:** The latest verion of reloader is using `apiVersion: rbac.authorization.k8s.io/v1` for rbac. The `apiVersion: rbac.authorization.k8s.io/v1beta1` is depreciated since kubernetes = 1.17. To run it with older versions, please use below command.
-
-```bash
-helm install stakater/reloader --set reloader.legacy.rbac=true # For helm3 add --generate-name flag or set the release name
 ```
 
 **Note:** By default reloader watches in all namespaces. To watch in single namespace, please run following command. It will install reloader in `test` namespace which will only watch `Deployments`, `Daemonsets` and `Statefulsets` in `test` namespace.

--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
-{{- if and .Values.reloader.legacy.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{ else }}
+{{- if  (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{ else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
-{{- if and .Values.reloader.legacy.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{ else }}
+{{- if  (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{ else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -1,8 +1,8 @@
 {{- if and (not (.Values.reloader.watchGlobally)) (.Values.reloader.rbac.enabled) }}
-{{- if and .Values.reloader.legacy.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{ else }}
+{{- if  (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{ else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: Role
 metadata:

--- a/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 {{- if and (not (.Values.reloader.watchGlobally)) (.Values.reloader.rbac.enabled) }}
-{{- if and .Values.reloader.legacy.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{ else }}
+{{- if  (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{ else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: RoleBinding
 metadata:
   annotations:
 {{ include "reloader-helm3.annotations" . | indent 4 }}
-  labels: 
+  labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
 {{ toYaml .Values.reloader.rbac.labels | indent 4 }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -17,8 +17,6 @@ reloader:
   watchGlobally: true
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
   readOnlyRootFileSystem: false
-  legacy:
-    rbac: false
   matchLabels: {}
   deployment:
     nodeSelector:
@@ -93,7 +91,7 @@ reloader:
     labels: {}
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
-    name: 
+    name:
   # Optional flags to pass to the Reloader entrypoint
   # Example:
   #   custom_annotations:
@@ -111,4 +109,4 @@ reloader:
     # labels:
     # Set timeout for scrape
     # timeout: 10s
-  
+


### PR DESCRIPTION
Checking api availability should allow us to avoid using values to determine which api to use, since v1beta1 was deprecated in k8s 1.17