### PR TITLE
Add support for argo rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 ## Problem
 
-We would like to watch if some change happens in `ConfigMap` and/or `Secret`; then perform a rolling upgrade on relevant `DeploymentConfig`, `Deployment`, `Daemonset` and `Statefulset`
+We would like to watch if some change happens in `ConfigMap` and/or `Secret`; then perform a rolling upgrade on relevant `DeploymentConfig`, `Deployment`, `Daemonset`, `Statefulset` and `Rollout`
 
 ## Solution
 
-Reloader can watch changes in `ConfigMap` and `Secret` and do rolling upgrades on Pods with their associated `DeploymentConfigs`, `Deployments`, `Daemonsets` and `Statefulsets`.
+Reloader can watch changes in `ConfigMap` and `Secret` and do rolling upgrades on Pods with their associated `DeploymentConfigs`, `Deployments`, `Daemonsets` `Statefulsets` and `Rollouts`.
 
 ## Compatibility
 
@@ -36,11 +36,11 @@ spec:
   template: metadata:
 ```
 
-This will discover deployments/daemonsets/statefulset automatically where `foo-configmap` or `foo-secret` is being used either via environment variable or from volume mount. And it will perform rolling upgrade on related pods when `foo-configmap` or `foo-secret`are updated.
+This will discover deploymentconfigs/deployments/daemonsets/statefulset/rollouts automatically where `foo-configmap` or `foo-secret` is being used either via environment variable or from volume mount. And it will perform rolling upgrade on related pods when `foo-configmap` or `foo-secret`are updated.
 
 You can restrict this discovery to only `ConfigMap` or `Secret` objects that
 are tagged with a special annotation. To take advantage of that, annotate
-your deployment/daemonset/statefulset like this:
+your deploymentconfigs/deployments/daemonsets/statefulset/rollouts like this:
 
 ```yaml
 kind: Deployment
@@ -63,7 +63,7 @@ data:
   key: value
 ```
 
-provided the secret/configmap is being used in an environment variable or a
+provided the secret/configmap is being used in an environment variable, or a
 volume mount.
 
 Please note that `reloader.stakater.com/search` and
@@ -73,7 +73,7 @@ will always restart upon a change in configmaps or secrets it uses, regardless
 of whether they have the `reloader.stakater.com/match: "true"` annotation or
 not.
 
-We can also specify a specific configmap or secret which would trigger rolling upgrade only upon change in our specified configmap or secret, this way, it will not trigger rolling upgrade upon changes in all configmaps or secrets used in a deployment, daemonset or statefulset.
+We can also specify a specific configmap or secret which would trigger rolling upgrade only upon change in our specified configmap or secret, this way, it will not trigger rolling upgrade upon changes in all configmaps or secrets used in a deploymentconfig, deployment, daemonset, statefulset or rollout.
 To do this either set the auto annotation to `"false"` (`reloader.stakater.com/auto: "false"`) or remove it altogether, and use annotations mentioned [here](#Configmap) or [here](#Secret)
 
 ### Configmap
@@ -131,6 +131,7 @@ spec:
 ### NOTES
 
 - Reloader also supports [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets). [Here](docs/Reloader-with-Sealed-Secrets.md) are the steps to use sealed-secrets with reloader.
+- For [rollouts](https://github.com/argoproj/argo-rollouts/) reloader simply triggers a change is up to you how you configure the rollout strategy.
 - `reloader.stakater.com/auto: "true"` will only reload the pod, if the configmap or secret is used (as a volume mount or as an env) in `DeploymentConfigs/Deployment/Daemonsets/Statefulsets`
 - `secret.reloader.stakater.com/reload` or `configmap.reloader.stakater.com/reload` annotation will reload the pod upon changes in specified configmap or secret, irrespective of the usage of configmap or secret.
 - you may override the auto annotation with the `--auto-annotation` flag
@@ -154,7 +155,7 @@ You can apply vanilla manifests by changing `RELEASE-NAME` placeholder provided 
 kubectl apply -f https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/reloader.yaml
 ```
 
-By default Reloader gets deployed in `default` namespace and watches changes `secrets` and `configmaps` in all namespaces.
+By default, Reloader gets deployed in `default` namespace and watches changes `secrets` and `configmaps` in all namespaces.
 
 Reloader can be configured to ignore the resources `secrets` and `configmaps` by passing the following args (`spec.template.spec.containers.args`) to its container :
 
@@ -201,7 +202,7 @@ helm repo update
 helm install stakater/reloader # For helm3 add --generate-name flag or set the release name
 ```
 
-**Note:** By default reloader watches in all namespaces. To watch in single namespace, please run following command. It will install reloader in `test` namespace which will only watch `Deployments`, `Daemonsets` and `Statefulsets` in `test` namespace.
+**Note:** By default reloader watches in all namespaces. To watch in single namespace, please run following command. It will install reloader in `test` namespace which will only watch `Deployments`, `Daemonsets` `Statefulsets` and `Rollouts` in `test` namespace.
 
 ```bash
 helm install stakater/reloader --set reloader.watchGlobally=false --namespace test # For helm3 add --generate-name flag or set the release name
@@ -224,7 +225,7 @@ You can enable to scrape Reloader's Prometheus metrics by setting `serviceMonito
 
 ### Documentation
 
-You can find more documentation [here](docs/)
+You can find more documentation [here](docs)
 
 ### Have a question?
 

--- a/docs/How-it-works.md
+++ b/docs/How-it-works.md
@@ -37,7 +37,7 @@ metadata:
 ```
 <small>*the default annotation can be changed with the `--secret-annotation` flag</small>
 
-Above mentioned annotation are also work for `Daemonsets` and `Statefulsets`
+Above mentioned annotation are also work for `Daemonsets` `Statefulsets` and `Rollouts`
 
 ## How Rolling upgrade works?
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,3 +5,4 @@ These are the key features of Reloader:
 1. Restart pod in a deployment on change in linked/related configmap's or secret's
 2. Restart pod in a daemonset on change in linked/related configmap's or secret's
 3. Restart pod in a statefulset on change in linked/related configmap's or secret's
+4. Restart pod in a rollout on change in linked/related configmap's or secret's

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stakater/Reloader
 go 1.15
 
 require (
+	github.com/argoproj/argo-rollouts v0.7.2
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,16 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/PuerkitoBio/purell v1.0.0 h1:0GoNN3taZV6QI81IXgCbxMyEaJDXMSIjArYBCYzVVvs=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2 h1:JCHLVE3B+kJde7bIEo5N4J+ZbLhp0J1Fs+ulyRws4gE=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/argoproj/argo-rollouts v0.7.2 h1:eUtsstL3DWNv+SxjnwJEBOHH2KOF5lu5G/zF5yKgC3A=
+github.com/argoproj/argo-rollouts v0.7.2/go.mod h1:zjMEXhycwvFGimOzpeiSmt/Cv58I63nGgVuROKFIfB8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -30,6 +34,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1/YsqVWoWNLQO+fusocsw354rqGTZtAgw=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -42,9 +47,13 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1 h1:wSt/4CYxs70xbATrGXhokKF1i0tZjENLOo1ioIO13zk=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
+github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9 h1:tF+augKRWlWx0J0B7ZyyKSiTyV6E1zZe+7b3qQlcEf8=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
+github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501 h1:C1JKChikHGpXwT5UQDFaryIpDtyyGL/CR6C2kB7F1oc=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
+github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87 h1:zP3nY8Tk2E6RTkqGYrarZXuzh+ffyLDljLxCy1iJw80=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -112,6 +121,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a h1:TpvdAwDAt1K4ANVOfcihouRdvP+MgAfDWwBuct4l6ZY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/internal/pkg/callbacks/rolling_upgrade.go
+++ b/internal/pkg/callbacks/rolling_upgrade.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	argorolloutv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	openshiftv1 "github.com/openshift/api/apps/v1"
 )
 
@@ -80,6 +81,15 @@ func GetDeploymentConfigItems(clients kube.Clients, namespace string) []interfac
 	return util.InterfaceSlice(deploymentConfigs.Items)
 }
 
+// GetRolloutItems returns the rollouts in given namespace
+func GetRolloutItems(clients kube.Clients, namespace string) []interface{} {
+	rollouts, err := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).List(meta_v1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("Failed to list Rollouts %v", err)
+	}
+	return util.InterfaceSlice(rollouts.Items)
+}
+
 // GetDeploymentAnnotations returns the annotations of given deployment
 func GetDeploymentAnnotations(item interface{}) map[string]string {
 	return item.(appsv1.Deployment).ObjectMeta.Annotations
@@ -98,6 +108,11 @@ func GetStatefulSetAnnotations(item interface{}) map[string]string {
 // GetDeploymentConfigAnnotations returns the annotations of given deploymentConfig
 func GetDeploymentConfigAnnotations(item interface{}) map[string]string {
 	return item.(openshiftv1.DeploymentConfig).ObjectMeta.Annotations
+}
+
+// GetRolloutAnnotations returns the annotations of given rollout
+func GetRolloutAnnotations(item interface{}) map[string]string {
+	return item.(argorolloutv1alpha1.Rollout).ObjectMeta.Annotations
 }
 
 // GetDeploymentPodAnnotations returns the pod's annotations of given deployment
@@ -120,6 +135,11 @@ func GetDeploymentConfigPodAnnotations(item interface{}) map[string]string {
 	return item.(openshiftv1.DeploymentConfig).Spec.Template.ObjectMeta.Annotations
 }
 
+// GetRolloutPodAnnotations returns the pod's annotations of given rollout
+func GetRolloutPodAnnotations(item interface{}) map[string]string {
+	return item.(argorolloutv1alpha1.Rollout).Spec.Template.ObjectMeta.Annotations
+}
+
 // GetDeploymentContainers returns the containers of given deployment
 func GetDeploymentContainers(item interface{}) []v1.Container {
 	return item.(appsv1.Deployment).Spec.Template.Spec.Containers
@@ -140,6 +160,11 @@ func GetDeploymentConfigContainers(item interface{}) []v1.Container {
 	return item.(openshiftv1.DeploymentConfig).Spec.Template.Spec.Containers
 }
 
+// GetRolloutContainers returns the containers of given rollout
+func GetRolloutContainers(item interface{}) []v1.Container {
+	return item.(argorolloutv1alpha1.Rollout).Spec.Template.Spec.Containers
+}
+
 // GetDeploymentInitContainers returns the containers of given deployment
 func GetDeploymentInitContainers(item interface{}) []v1.Container {
 	return item.(appsv1.Deployment).Spec.Template.Spec.InitContainers
@@ -158,6 +183,11 @@ func GetStatefulSetInitContainers(item interface{}) []v1.Container {
 // GetDeploymentConfigInitContainers returns the containers of given deploymentConfig
 func GetDeploymentConfigInitContainers(item interface{}) []v1.Container {
 	return item.(openshiftv1.DeploymentConfig).Spec.Template.Spec.InitContainers
+}
+
+// GetRolloutInitContainers returns the containers of given rollout
+func GetRolloutInitContainers(item interface{}) []v1.Container {
+	return item.(argorolloutv1alpha1.Rollout).Spec.Template.Spec.InitContainers
 }
 
 // UpdateDeployment performs rolling upgrade on deployment
@@ -188,6 +218,16 @@ func UpdateDeploymentConfig(clients kube.Clients, namespace string, resource int
 	return err
 }
 
+// UpdateRollout performs rolling upgrade on rollout
+func UpdateRollout(clients kube.Clients, namespace string, resource interface{}) error {
+	rollout := resource.(argorolloutv1alpha1.Rollout)
+	rolloutBefore, _ := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Get(rollout.Name, meta_v1.GetOptions{})
+	logrus.Warnf("Before: %+v", rolloutBefore.Spec.Template.Spec.Containers[0].Env)
+	logrus.Warnf("After: %+v", rollout.Spec.Template.Spec.Containers[0].Env)
+	_, err := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Update(&rollout)
+	return err
+}
+
 // GetDeploymentVolumes returns the Volumes of given deployment
 func GetDeploymentVolumes(item interface{}) []v1.Volume {
 	return item.(appsv1.Deployment).Spec.Template.Spec.Volumes
@@ -206,4 +246,9 @@ func GetStatefulSetVolumes(item interface{}) []v1.Volume {
 // GetDeploymentConfigVolumes returns the Volumes of given deploymentConfig
 func GetDeploymentConfigVolumes(item interface{}) []v1.Volume {
 	return item.(openshiftv1.DeploymentConfig).Spec.Template.Spec.Volumes
+}
+
+// GetRolloutVolumes returns the Volumes of given rollout
+func GetRolloutVolumes(item interface{}) []v1.Volume {
+	return item.(argorolloutv1alpha1.Rollout).Spec.Template.Spec.Volumes
 }

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -71,6 +71,20 @@ func GetDeploymentConfigRollingUpgradeFuncs() callbacks.RollingUpgradeFuncs {
 	}
 }
 
+// GetArgoRolloutRollingUpgradeFuncs returns all callback funcs for a rollout
+func GetArgoRolloutRollingUpgradeFuncs() callbacks.RollingUpgradeFuncs {
+	return callbacks.RollingUpgradeFuncs{
+		ItemsFunc:          callbacks.GetRolloutItems,
+		AnnotationsFunc:    callbacks.GetRolloutAnnotations,
+		PodAnnotationsFunc: callbacks.GetRolloutPodAnnotations,
+		ContainersFunc:     callbacks.GetRolloutContainers,
+		InitContainersFunc: callbacks.GetRolloutInitContainers,
+		UpdateFunc:         callbacks.UpdateRollout,
+		VolumesFunc:        callbacks.GetRolloutVolumes,
+		ResourceType:       "Rollout",
+	}
+}
+
 func doRollingUpgrade(config util.Config, collectors metrics.Collectors) {
 	clients := kube.GetClients()
 
@@ -81,6 +95,8 @@ func doRollingUpgrade(config util.Config, collectors metrics.Collectors) {
 	if kube.IsOpenshift {
 		rollingUpgrade(clients, config, GetDeploymentConfigRollingUpgradeFuncs(), collectors)
 	}
+
+	rollingUpgrade(clients, config, GetArgoRolloutRollingUpgradeFuncs(), collectors)
 }
 
 func rollingUpgrade(clients kube.Clients, config util.Config, upgradeFuncs callbacks.RollingUpgradeFuncs, collectors metrics.Collectors) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
+	argorollout "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	appsclient "github.com/openshift/client-go/apps/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -15,6 +16,7 @@ import (
 type Clients struct {
 	KubernetesClient    kubernetes.Interface
 	OpenshiftAppsClient appsclient.Interface
+	ArgoRolloutClient   argorollout.Interface
 }
 
 var (
@@ -38,10 +40,26 @@ func GetClients() Clients {
 		}
 	}
 
+	var rolloutClient *argorollout.Clientset
+
+	rolloutClient, err = GetArgoRolloutClient()
+	if err != nil {
+		logrus.Warnf("Unable to create ArgoRollout client error = %v", err)
+	}
+
 	return Clients{
 		KubernetesClient:    client,
 		OpenshiftAppsClient: appsClient,
+		ArgoRolloutClient:   rolloutClient,
 	}
+}
+
+func GetArgoRolloutClient() (*argorollout.Clientset, error) {
+	config, err := getConfig()
+	if err != nil {
+		return nil, err
+	}
+	return argorollout.NewForConfig(config)
 }
 
 func isOpenshift() bool {


### PR DESCRIPTION
I use reloader quite extensively in my workplace. Our main concern is restarting old applications whenever the underlying secrets get updated so they take action. We are very happy with the project is simple, powerful and easy to use.

Lately we started to look into more sophisticated deployment mechanisms and we decided to go for Argo Rollouts, this helps us better control the blast radius of any change.

This MR simply adds support into reloader to perform an update into these types of objects