### PR TITLE
Added multi-arch docker image for Github actions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -98,6 +98,7 @@ jobs:
         push: true
         build-args: BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
         cache-to: type=inline
+        platforms: linux/amd64,linux/arm,linux/arm64
         tags: |
           ${{ env.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
         labels: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -99,6 +99,7 @@ jobs:
           push: true
           build-args: BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
           cache-to: type=inline
+          platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           labels: |


### PR DESCRIPTION
Following instruction from [docker/build-push-action](https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md) Github action, I added multi-arch docker images support.

The three supported platform are arm, arm64 and amd64, which add support for Raspberry Pi 2/3/4, and the new Arm Apple processors.

Fixes #203