### PR TITLE
Dockerfile now use the platform supplied by buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build the manager binary
-FROM golang:1.15.2 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.15.2 as builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 
@@ -16,7 +19,7 @@ COPY internal/ internal/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build  -mod=mod -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build  -mod=mod -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This replace the hardcoded linux/amd64 architecture in the Dockerfile to the target architecture provided by Docker buildx.

This fixes issues #209 and #210