### PR TITLE
Make argo rollouts optional

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
           - mountPath: /tmp/
             name: tmp-volume
       {{- end }}
-      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) }}
+      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) (eq .Values.reloader.isArgoRollouts true) }}
         args:
           {{- if .Values.reloader.logFormat }}
           - "--log-format={{ .Values.reloader.logFormat }}"
@@ -143,6 +143,9 @@ spec:
           - "--search-match-annotation"
           - "{{ .Values.reloader.custom_annotations.match }}"
             {{- end }}
+          {{- end }}
+          {{- if eq .Values.reloader.isArgoRollouts true }}
+          - "--is-Argo-Rollouts={{ .Values.reloader.isArgoRollouts }}"
           {{- end }}
       {{- end }}
       {{- if .Values.reloader.deployment.resources }}

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -9,6 +9,7 @@ kubernetes:
   host: https://kubernetes.default
 
 reloader:
+  isArgoRollouts: false
   isOpenshift: false
   ignoreSecrets: false
   ignoreConfigMaps: false

--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -32,6 +32,7 @@ func NewReloaderCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&options.LogFormat, "log-format", "", "Log format to use (empty string for text, or JSON")
 	cmd.PersistentFlags().StringSlice("resources-to-ignore", []string{}, "list of resources to ignore (valid options 'configMaps' or 'secrets')")
 	cmd.PersistentFlags().StringSlice("namespaces-to-ignore", []string{}, "list of namespaces to ignore")
+	cmd.PersistentFlags().StringVar(&options.IsArgoRollouts, "is-Argo-Rollouts", "false", "Add support for argo rollouts")
 	return cmd
 }
 

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -96,7 +96,9 @@ func doRollingUpgrade(config util.Config, collectors metrics.Collectors) {
 		rollingUpgrade(clients, config, GetDeploymentConfigRollingUpgradeFuncs(), collectors)
 	}
 
-	rollingUpgrade(clients, config, GetArgoRolloutRollingUpgradeFuncs(), collectors)
+	if options.IsArgoRollouts == "true" {
+		rollingUpgrade(clients, config, GetArgoRolloutRollingUpgradeFuncs(), collectors)
+	}
 }
 
 func rollingUpgrade(clients kube.Clients, config util.Config, upgradeFuncs callbacks.RollingUpgradeFuncs, collectors metrics.Collectors) {

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -17,4 +17,6 @@ var (
 	SearchMatchAnnotation = "reloader.stakater.com/match"
 	// LogFormat is the log format to use (json, or empty string for default)
 	LogFormat = ""
+	// Adds support for argo rollouts
+	IsArgoRollouts = "false"
 )


### PR DESCRIPTION
Signed-off-by: faizanahmad055 <faizan.ahmad55@outlook.com>

Should fix #207 

It makes argo rollouts optional. To enable argo rollouts, the [isArgoRollouts](https://github.com/stakater/Reloader/blob/master/deployments/kubernetes/chart/reloader/values.yaml#L12) in values.yaml must be true.