### PR TITLE
Propagate error to enable retry

### DIFF
--- a/internal/pkg/controller/controller.go
+++ b/internal/pkg/controller/controller.go
@@ -145,7 +145,7 @@ func (c *Controller) handleErr(err error, key interface{}) {
 
 	// This controller retries 5 times if something goes wrong. After that, it stops trying.
 	if c.queue.NumRequeues(key) < 5 {
-		logrus.Errorf("Error syncing events %v: %v", key, err)
+		logrus.Errorf("Error syncing events: %v", err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.

--- a/internal/pkg/handler/create.go
+++ b/internal/pkg/handler/create.go
@@ -20,7 +20,7 @@ func (r ResourceCreatedHandler) Handle() error {
 	} else {
 		config, _ := r.GetConfig()
 		// process resource based on its type
-		doRollingUpgrade(config, r.Collectors)
+		return doRollingUpgrade(config, r.Collectors)
 	}
 	return nil
 }

--- a/internal/pkg/handler/update.go
+++ b/internal/pkg/handler/update.go
@@ -22,7 +22,7 @@ func (r ResourceUpdatedHandler) Handle() error {
 		config, oldSHAData := r.GetConfig()
 		if config.SHAValue != oldSHAData {
 			// process resource based on its type
-			doRollingUpgrade(config, r.Collectors)
+			return doRollingUpgrade(config, r.Collectors)
 		}
 	}
 	return nil


### PR DESCRIPTION
Relates to https://github.com/stakater/Reloader/issues/144

**problem**
A potential error in `PerformRollingUpgrade` seems to never reach the `Handle` method, causing updates to not be retried when errors occur. I also suspect that an error in the loop within `PerformRollingUpgrade` may be overwritten by the next loop iteration. Does `PerformRollingUpgrade` correctly return errors and are there any reasons for not propagating the error further than to the `rollingUpgrade` function?

**suggestion**
I have drafted a suggestion that will break the loop in `PerformRollingUpgrade`  when an error occurs. Additionally, the error logged in `rollingUpgrade` is now propagated back to the `Handle` function, so that the update is requeued.

I am new to this codebase and would love some feedback on this 😃 