### PR TITLE
Only enable Rollouts when enabled in Helm chart.

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -44,7 +44,7 @@ rules:
       - update
       - patch
 {{- end }}
-{{- if or (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1") (.Values.reloader.isArgoRollouts) }}
+{{- if and (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1") (.Values.reloader.isArgoRollouts) }}
   - apiGroups:
       - "argoproj.io"
       - ""

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -44,7 +44,7 @@ rules:
       - update
       - patch
 {{- end }}
-{{- if or (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1") (.Values.reloader.isArgoRollouts) }}
+{{- if and (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1") (.Values.reloader.isArgoRollouts) }}
   - apiGroups:
       - "argoproj.io"
       - ""


### PR DESCRIPTION
This prevents a permission issue in case Rollouts is available on a cluster, but the user does not have permission to use it (e.g. as a tenant on a cluster without cluster admin rights), and therefore also may not set permissions for it.

See issue #231.