### PR TITLE
Fix typo in Chart.yaml sources

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - kubernetes
 home: https://github.com/stakater/Reloader
 sources:
-  - https://github.com/stakater/IngressMonitorController
+  - https://github.com/stakater/Reloader
 icon: https://raw.githubusercontent.com/stakater/Reloader/master/assets/web/reloader-round-100px.png
 maintainers:
   - name: Stakater


### PR DESCRIPTION
I'm assuming the source listed in Chart.yaml is supposed to be for Reloader and not IngressMonitorController, so here's a quick patch.