### PR TITLE
fix: kustomize patch for `clusterrole` and `clusterrolebinding`

### DIFF
--- a/deployments/kubernetes/kustomization.yaml
+++ b/deployments/kubernetes/kustomization.yaml
@@ -8,3 +8,11 @@ resources:
   - manifests/rolebinding.yaml
   - manifests/serviceaccount.yaml
   - manifests/deployment.yaml
+
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+    patch: |-
+      - op: replace
+        path: /apiVersion
+        value: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is a temporary kustomize patch to fix the issues with deploying reloader against a kubernetes 1.22 cluster