### PR TITLE
Add container security context support for Helm chart

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
           periodSeconds: {{ .Values.reloader.deployment.readinessProbe.periodSeconds | default "10" }}
           successThreshold: {{ .Values.reloader.deployment.readinessProbe.successThreshold | default "1" }}
 
+      {{- with .Values.reloader.deployment.containerSecurityContext }}
+        securityContext: {{ toYaml . | nindent 10 }}
+      {{- end }}
+
       {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
         volumeMounts:
           - mountPath: /tmp/

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -41,6 +41,14 @@ reloader:
       runAsNonRoot: true
       runAsUser: 65534
 
+    containerSecurityContext: {}
+      # capabilities:
+      #   drop:
+      #     - ALL
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: true
+
+
     # A list of tolerations to be applied to the Deployment.
     # Example:
     #   tolerations:

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -48,7 +48,6 @@ reloader:
       # allowPrivilegeEscalation: false
       # readOnlyRootFilesystem: true
 
-
     # A list of tolerations to be applied to the Deployment.
     # Example:
     #   tolerations:

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -40,6 +40,13 @@ reloader:
       runAsNonRoot: true
       runAsUser: 65534
 
+    containerSecurityContext: {}
+      # capabilities:
+      #   drop:
+      #     - ALL
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: true
+
     # A list of tolerations to be applied to the Deployment.
     # Example:
     #   tolerations:


### PR DESCRIPTION
I modified the helm chart values and template file to support container security context to fix #261

There are some questions / TODO things needs development team's help, so I leave them here:

**Weather do I need to change the Kubernetes manifest files or Helm Chart's version, maybe it's maintained by automation jobs?**

Just want to confirm this one because I did find bump up logic in the file `.github/workflows/push.yaml`.

**Another one is, I think `reloader.readOnlyRootFileSystem` is not very good configuration item when the container's security context configuration added, do you need to make a backward compatibility? I don't found any changelog for helm chart itself.**

I have plan to refine this pull request if needed, I think moving  `reloader.readOnlyRootFileSystem` to  `reloader.deployment.containerSecurityContext.readOnlyRootFileSystem` makes more sense, and If backward compatibility is needed, the logic for `tmp` volume mounting (in the file [deployment.yaml](https://github.com/stakater/Reloader/blob/766bc24241d252dfd5707cc0cc68bf04ce5d0a2c/deployments/kubernetes/chart/reloader/templates/deployment.yaml#L117-L121)) may be:

- if `reloader.readOnlyRootFileSystem` is set, using it to override `reloader.deployment.containerSecurityContext.readOnlyRootFileSystem` value, even if the value later is set.
