### PR TITLE
Enable internal builds without direct Internet access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ COPY internal/ internal/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build  -mod=mod -a -o manager main.go
+RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GO111MODULE=on \
+    go build -mod=mod -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
+
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.17.2 as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.17.2} as builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -23,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM ${BASE_IMAGE:-gcr.io/distroless/static:nonroot}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.17.2} as builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOPROXY
+ARG GOPRIVATE
 
 WORKDIR /workspace
 
@@ -25,6 +27,8 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
+    GOPROXY=${GOPROXY} \
+    GOPRIVATE=${GOPRIVATE} \
     GO111MODULE=on \
     go build -mod=mod -a -o manager main.go
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ OS ?= linux
 ARCH ?= ???
 ALL_ARCH ?= arm64 arm amd64
 
-BUILDER ?= reloader-builder-${ARCH}
+BUILDER_IMAGE ?=
+BASE_IMAGE    ?=
 BINARY ?= Reloader
 DOCKER_IMAGE ?= stakater/reloader
 
@@ -33,7 +34,15 @@ build:
 	"$(GOCMD)" build ${GOFLAGS} ${LDFLAGS} -o "${BINARY}"
 
 build-image:
-	docker buildx build --platform ${OS}/${ARCH} --build-arg GOARCH=$(ARCH) -t "${REPOSITORY_ARCH}" --load -f Dockerfile .
+	docker buildx build \
+		--platform ${OS}/${ARCH} \
+		--build-arg GOARCH=$(ARCH) \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg BASE_IMAGE=${BASE_IMAGE} \
+		-t "${REPOSITORY_ARCH}" \
+		--load \
+		-f Dockerfile \
+		.
 
 push:
 	docker push ${REPOSITORY_ARCH}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ BUILD=
 GOCMD = go
 GOFLAGS ?= $(GOFLAGS:)
 LDFLAGS =
+GOPROXY   ?=
+GOPRIVATE ?=
 
 default: build test
 
@@ -39,6 +41,8 @@ build-image:
 		--build-arg GOARCH=$(ARCH) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
+		--build-arg GOPROXY=${GOPROXY} \
+		--build-arg GOPRIVATE=${GOPRIVATE} \
 		-t "${REPOSITORY_ARCH}" \
 		--load \
 		-f Dockerfile \


### PR DESCRIPTION
When building reloader in environments without direct Internet access, the builder image, the base image and GOPROXY/GOPRIVATE needs to be configurable.

This PR makes the images configurable without changing the default values.