### PR TITLE
feat(kubernetes/chart): explicitly mount service-account-token in dep…

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -178,6 +178,9 @@ spec:
       securityContext: {{ toYaml .Values.reloader.deployment.securityContext | nindent 8 }}
 {{- end }}
       serviceAccountName: {{ template "reloader-serviceAccountName" . }}
+{{- if hasKey .Values.reloader.deployment "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.reloader.deployment.automountServiceAccountToken }}
+{{- end }}
     {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
       volumes:
         - emptyDir: {}

--- a/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
+{{- if hasKey .Values.reloader.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.reloader.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   annotations:
 {{ include "reloader-helm3.annotations" . | indent 4 }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -118,7 +118,7 @@ reloader:
     annotations: {}
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
-    name:
+    name: 
   # Optional flags to pass to the Reloader entrypoint
   # Example:
   #   custom_annotations:


### PR DESCRIPTION
Our environment has some restrictions on service-accounts: We're not allowed to use automountServiceAccountToken=true as default for a service-account but have to explicit enable the service-account-mount in each deployment. 
It would be nice, if you could merge that change to make Reloader usable in such einvironments.