### PR TITLE
the specific configmap/secret name can be regexp-ly selected

### DIFF
--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stakater/Reloader/internal/pkg/util"
 	"github.com/stakater/Reloader/pkg/kube"
 	v1 "k8s.io/api/core/v1"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -154,8 +155,9 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 		if result != constants.Updated && annotationValue != "" {
 			values := strings.Split(annotationValue, ",")
 			for _, value := range values {
-				value = strings.Trim(value, " ")
-				if value == config.ResourceName {
+				value = strings.TrimSpace(value)
+				re := regexp.MustCompile("^" + value + "$")
+				if re.Match([]byte(config.ResourceName)) {
 					result = invokeReloadStrategy(upgradeFuncs, i, config, false)
 					if result == constants.Updated {
 						break


### PR DESCRIPTION
To make the name of secret/configmap in annotation can be used regular expression.
e.g. with new code change, secret.reloader.stakater.com/reload: "foo-secret.*"

```bash
kind: Deployment
metadata:
  annotations:
    secret.reloader.stakater.com/reload: "foo-secret2two"
spec:
```