### PR TITLE
Remove server side call from podmonitoring template

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.reloader.podMonitor.enabled ) }}
+{{- if ( .Values.reloader.podMonitor.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:


### PR DESCRIPTION
The `.Capabilities.APIVersions.Has` is server side, which means it breaks in workflows where `helm template` is used (ArgoCD for example)