### PR TITLE
Add pod disruption budget

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.reloader.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "reloader-fullname" . }}
+spec:
+  minAvailable: {{ .Values.reloader.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "reloader-fullname" . }}
+{{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -153,3 +153,8 @@ reloader:
     # labels:
     # Set timeout for scrape
     # timeout: 10s
+
+  podDisruptionBudget:
+    enabled: false
+    # Set the minimum available replicas
+    # minAvailable: 1


### PR DESCRIPTION
Adds an optional pod disruption budget to the helm chart. 

The intention of this PR is to merge it after the HA PR https://github.com/stakater/Reloader/pull/341 and to stop the already very large diff of that PR getting any larger. 