### PR TITLE
Fix lock name typo

### DIFF
--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -23,7 +23,7 @@ const (
 
 // Leadership election related consts
 const (
-	LockName        string = "stakaer-reloader-lock"
+	LockName        string = "stakater-reloader-lock"
 	PodNameEnv      string = "POD_NAME"
 	PodNamespaceEnv string = "POD_NAMESPACE"
 )


### PR DESCRIPTION
Fixes the typo I introduced that was raised in: https://github.com/stakater/Reloader/issues/349