### PR TITLE
[Helm chart] Add support for ImagePullSecrets

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
 {{ toYaml .Values.reloader.matchLabels | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.reloader.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.reloader.deployment.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.reloader.deployment.nodeSelector | indent 8 }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -108,6 +108,8 @@ reloader:
     pod:
       annotations: {}
     priorityClassName: ""
+    # imagePullSecrets:
+    #   - name: myregistrykey
 
   service: {}
     # labels: {}


### PR DESCRIPTION
Add support for ImagePullSecrets in the Helm chart. 
This can be useful, for example, to make use of dockerhub credentials for increased pull limits.