### PR TITLE
Enable ability to override Release.Namespace for target namespace

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role-binding
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -25,5 +25,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "reloader-serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+   namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
 {{- if not (.Values.reloader.enableHA) }}
   replicas: 1
@@ -114,7 +114,7 @@ spec:
         ports:
         - name: http
           containerPort: 9091
-        - name: metrics 
+        - name: metrics
           containerPort: 9090
         livenessProbe:
           httpGet:

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role-binding
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -25,5 +25,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "reloader-serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+   namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/secret.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "reloader-fullname" . }}
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 type: Opaque
 data:
   {{ if .Values.reloader.deployment.env.secret.ALERT_ON_RELOAD -}}

--- a/deployments/kubernetes/chart/reloader/templates/service.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml .Values.reloader.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   selector:
 {{- if .Values.reloader.deployment.labels }}

--- a/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
@@ -22,5 +22,5 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+ namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Changing  

namespace: {{ .Release.Namespace }}

to

namespace: {{ .Values.namespace | default .Release.Namespace }}

To add flexibility to deploy to its own namespace when used in an umbrella chart concept