### PR TITLE
Add option to use existing secret to Helm chart

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       - image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
         imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
         name: {{ template "reloader-fullname" . }}
-      {{- if or (.Values.reloader.deployment.env.open) (.Values.reloader.deployment.env.secret) (.Values.reloader.deployment.env.field) (eq .Values.reloader.watchGlobally false) (.Values.reloader.enableHA)}}
+      {{- if or (.Values.reloader.deployment.env.open) (.Values.reloader.deployment.env.secret) (.Values.reloader.deployment.env.field) (.Values.reloader.deployment.env.existing) (eq .Values.reloader.watchGlobally false) (.Values.reloader.enableHA)}}
         env:
       {{- range $name, $value := .Values.reloader.deployment.env.open }}
       {{- if not (empty $value) }}
@@ -83,6 +83,17 @@ spec:
             secretKeyRef:
               name: {{ $secret_name }}
               key: {{ $name | quote }}
+      {{- end }}
+      {{- end }}
+      {{- range $secret, $values := .Values.reloader.deployment.env.existing }}
+      {{- range $name, $key := $values }}
+      {{- if not ( empty $name) }}
+        - name: {{ $name | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secret | quote }}
+              key: {{ $key | quote }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{- range $name, $value := .Values.reloader.deployment.env.field }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -82,6 +82,15 @@ reloader:
       #  ALERT_ADDITIONAL_INFO: <"Additional Info like Cluster Name if needed">
       # field supports Key value pair as environment variables. It gets the values from other fields of pod.
       field:
+      # existing secret, you can specify multiple existing secrets, for each
+      # specify the env var name followed by the key in existing secret that
+      # will be used to populate the env var
+      existing:
+      #  existing_secret_name:
+      #    ALERT_ON_RELOAD: alert_on_reload_key
+      #    ALERT_SINK: alert_sink_key
+      #    ALERT_WEBHOOK_URL: alert_webhook_key
+      #    ALERT_ADDITIONAL_INFO: alert_additional_info_key
 
     # Liveness and readiness probe timeout values.
     livenessProbe: {}


### PR DESCRIPTION
Hi, I've added an option to use existing secrets for env values in reloader deployment. At our company we use a synchronization tool to populate secret values and would like to use the secrets to hold e.g. slack webhook url.

I've also added a comment to values.yaml on how to use this new feature.