### PR TITLE
Remove namespace from ClusterRole and ClusterRoleBinding

### DIFF
--- a/deployments/kubernetes/manifests/clusterrole.yaml
+++ b/deployments/kubernetes/manifests/clusterrole.yaml
@@ -14,7 +14,6 @@ metadata:
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role
-  namespace: default
 rules:
   - apiGroups:
       - ""

--- a/deployments/kubernetes/manifests/clusterrolebinding.yaml
+++ b/deployments/kubernetes/manifests/clusterrolebinding.yaml
@@ -14,7 +14,6 @@ metadata:
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role-binding
-  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
When using Kustomize (with Terraform, although I believe it's Kustomize complaining), I get error messages saying that non-namespaced resources have namespaces set:

```
$ tf apply
╷
│ Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff: "rbac.authorization.k8s.io/ClusterRole/default/reloader-reloader-role": is not namespace scoped but has metadata.namespace set
│ 
│   with module.reloader.kustomization_resource.reloader1["rbac.authorization.k8s.io/ClusterRole/default/reloader-reloader-role"],
│   on ../../modules/reloader/main.tf line 20, in resource "kustomization_resource" "reloader1":
│   20: resource "kustomization_resource" "reloader1" {
│ 
╵
╷
│ Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff: "rbac.authorization.k8s.io/ClusterRoleBinding/default/reloader-reloader-role-binding": is not namespace scoped but has metadata.namespace set
│ 
│   with module.reloader.kustomization_resource.reloader1["rbac.authorization.k8s.io/ClusterRoleBinding/default/reloader-reloader-role-binding"],
│   on ../../modules/reloader/main.tf line 20, in resource "kustomization_resource" "reloader1":
│   20: resource "kustomization_resource" "reloader1" {
│ 
╵
```

This PR simply removes the unnecessary namespace from these resources and fixes the above errors.