### PR TITLE
fix: remove cluster-scoped resources namespace

### DIFF
--- a/deployments/kubernetes/manifests/clusterrole.yaml
+++ b/deployments/kubernetes/manifests/clusterrole.yaml
@@ -14,7 +14,6 @@ metadata:
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role
-  namespace: default
 rules:
   - apiGroups:
       - ""

--- a/deployments/kubernetes/manifests/clusterrolebinding.yaml
+++ b/deployments/kubernetes/manifests/clusterrolebinding.yaml
@@ -14,7 +14,6 @@ metadata:
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role-binding
-  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
`/metadata/namespace` is invalid for cluster-scoped resources. Having it
defined results in errors in certain tooling.

```
KNV1052: cluster-scoped resources MUST NOT declare metadata.namespace
```
