### PR TITLE
Fixing eval for enabling HA

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
           {{- if ne .Values.reloader.reloadStrategy "default" }}
           - "--reload-strategy={{ .Values.reloader.reloadStrategy }}"
           {{- end }}
-          {{- if or (gt .Values.reloader.deployment.replicas 1.0) (.Values.reloader.enableHA) }}
+          {{- if or (gt .Values.reloader.deployment.replicas 1) (.Values.reloader.enableHA) }}
           - "--enable-ha=true"
           {{- end}}
       {{- end }}


### PR DESCRIPTION
When set to 1.0

 <gt .Values.reloader.deployment.replicas 1.0>: error calling gt: incompatible types for comparison

But works when set to 1