### PR TITLE
feat: Configmap/secret label selector & refactor namespace selector 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,16 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 | --resources-to-ignore=configMaps | To ignore configMaps |
 | --resources-to-ignore=secrets    | To ignore secrets    |
 
-`Note`: At one time only one of these resource can be ignored, trying to do it will cause error in Reloader. Workaround for ignoring both resources is by scaling down the reloader pods to `0`.
+**Note:** At one time only one of these resource can be ignored, trying to do it will cause error in Reloader. Workaround for ignoring both resources is by scaling down the reloader pods to `0`.
 
-Reloader can be configured to watch only secrets/configmaps labeled with (one or more) labels of your choosing by using the `--resource-label-selector` parameter.  Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). The `:` delimited key value mappings are deprecated and if provided will be translated to key=value. Likewise, if a wildcard is provided (e.g. `key:*`) it will be translated to just the standalone `key` which checks for key existence.
+Reloader can be configured to only watch secrets/configmaps with one or more labels using the `--resource-label-selector` parameter. Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). Additional examples of these selectors can be found in the [Kubernetes Docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors). 
 
-These can be combined together, for example:
+**Note:** The old `:` delimited key value mappings are deprecated and if provided will be translated to `key=value`. Likewise, if a wildcard value is provided (e.g. `key:*`) it will be translated to the standalone `key` which checks for key existence.
+
+These selectors can be combined together, for example with:
 
 ```
---resource-label-selector=reloader=enabled,key-exists,another-label in (value1, value2, value3)
+--resource-label-selector=reloader=enabled,key-exists,another-label in (value1,value2,value3)
 ```
 
 Only configmaps or secrets labeled like the following will be watched:
@@ -206,17 +208,16 @@ metadata:
   ...
 ```
 
-If you want to select namespace only by the key of the label use ```*``` as the value.
-For example, for ```--namespace-selector=select-this:*``` all namespaces with label-key "select-this" will be selected regardless of the labels value
+Reloader can be configured to only watch namespaces labeled with one or more labels using the `--namespace-selector` parameter. Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). Additional examples of these selectors can be found in the (Kubernetes Docs)[https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors]. 
 
-Reloader can be configured to watch only namespaces labeled with (one or more) labels of your choosing by using the `--namespace-selector` parameter. Reloader can be configured to watch only secrets/configmaps labeled with (one or more) labels of your choosing by using the `--resource-label-selector` parameter.  Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). The `:` delimited key value mappings are deprecated and if provided will be translated to key=value. Likewise, if a wildcard is provided (e.g. `key:*`) it will be translated to just the standalone `key` which checks for key existence.
+**Note:** The old `:` delimited key value mappings are deprecated and if provided will be translated to `key=value`. Likewise, if a wildcard value is provided (e.g. `key:*`) it will be translated to the standalone `key` which checks for key existence.
 
-These can be combined together, for example:
+These selectors can be combined together, for example with:
 ```
---namespace-selector=reloader:enabled,test:true
+--namespace-selector=reloader=enabled,test=true
 ```
 
-Only namespaces labeled like the following namespace YAML will be watched:
+Only namespaces labeled as below would be watched and eligible for reloads:
 ```yaml
 kind: Namespace
 apiVersion: v1
@@ -227,8 +228,6 @@ metadata:
     test: true
   ...
 ```
-If you want to select namespace only by the key of the label use ```*``` as the value.
-For example, for ```--namespace-selector=select-this:*``` all namespaces with label-key "select-this" will be selected regardless of the labels value
 
 ### Vanilla kustomize
 
@@ -279,19 +278,21 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 | ignoreSecrets    | To ignore secrets. Valid value are either `true` or `false`    | boolean |
 | ignoreConfigMaps | To ignore configMaps. Valid value are either `true` or `false` | boolean |
 
-`Note`: At one time only one of these resource can be ignored, trying to do it will cause error in helm template compilation.
+**Note:** At one time only one of these resource can be ignored, trying to do it will cause error in helm template compilation.
 
-Reloader can be configured to watch only namespaces labeled with (one or more) labels of your choosing by using the `namespaceSelector` parameter
+Reloader can be configured to only watch namespaces labeled with one or more labels using the `namespaceSelector` parameter
 
 | Parameter            | Description                                                                        | Type    |
 | ----------------     | ---------------------------------------------------------------------------------- | ------- |
 | namespaceSelector    | list of comma separated label selectors, if mulitple are provided they are ANDed   | string  |
 
-Reloader can be configured to watch only configmaps/secrets labeled with (one or more) labels of your choosing by using the `resourceLabelSelector` parameter
+Reloader can be configured to only watch configmaps/secrets labeled with one or more labels using the `resourceLabelSelector` parameter
 
 | Parameter              | Description                                                                        | Type    |
 | ---------------------- | ---------------------------------------------------------------------------------- | ------- |
 | resourceLabelSelector  | list of comma separated label selectors, if mulitple are provided they are ANDed   | string  |
+
+**Note:** Both `namespaceSelector` & `resourceLabelSelector` can be used together. If they are then both conditions must be met for the configmap or secret to be eligible to trigger reload events. (e.g. If a configMap matches `resourceLabelSelector` but `namespaceSelector` does not match the namespace the configmap is in, it will be ignored)
 
 You can also set the log format of Reloader to json by setting `logFormat` to `json` in values.yaml and apply the chart
 
@@ -352,7 +353,7 @@ PRs are welcome. In general, we follow the "fork-and-pull" Git workflow.
 4.  **Push** your work back up to your fork
 5.  Submit a **Pull request** so that we can review your changes
 
-NOTE: Be sure to merge the latest from "upstream" before making a pull request!
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ spec:
 - you may override the secret annotation with the `--secret-annotation` flag
 - you may want to prevent watching certain namespaces with the `--namespaces-to-ignore` flag
 - you may want to watch only a set of namespaces with certain labels by using the `--namespace-selector` flag
+- you may want to watch only a set of secrets/configmaps with certain labels by using the `--resource-label-selector` flag
 - you may want to prevent watching certain resources with the `--resources-to-ignore` flag
 - you can configure logging in JSON format with the `--log-format=json` option
 - you can configure the "reload strategy" with the `--reload-strategy=<strategy-name>` option (details below)
@@ -183,9 +184,36 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 
 `Note`: At one time only one of these resource can be ignored, trying to do it will cause error in Reloader. Workaround for ignoring both resources is by scaling down the reloader pods to `0`.
 
-Reloader can be configured to watch only namespaces labeled with (one or more) labels of your choosing by using the `--namespace-selector` parameter, for example:
+Reloader can be configured to watch only secrets/configmaps labeled with (one or more) labels of your choosing by using the `--resource-label-selector` parameter.  Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). The `:` delimited key value mappings are deprecated and if provided will be translated to key=value. Likewise, if a wildcard is provided (e.g. `key:*`) it will be translated to just the standalone `key` which checks for key existence.
+
+These can be combined together, for example:
+
 ```
---namespace-selector=reloder:enabled,test:true
+--resource-label-selector=reloader=enabled,key-exists,another-label in (value1, value2, value3)
+```
+
+Only configmaps or secrets labeled like the following will be watched:
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  ...
+  labels:
+    reloader: enabled
+    key-exists: yes
+    another-label: value1
+
+  ...
+```
+
+If you want to select namespace only by the key of the label use ```*``` as the value.
+For example, for ```--namespace-selector=select-this:*``` all namespaces with label-key "select-this" will be selected regardless of the labels value
+
+Reloader can be configured to watch only namespaces labeled with (one or more) labels of your choosing by using the `--namespace-selector` parameter. Reloader can be configured to watch only secrets/configmaps labeled with (one or more) labels of your choosing by using the `--resource-label-selector` parameter.  Supported operators are `!, in, notin, ==, =, !=`, if no operator is found the 'exists' operator is inferred (ie. key only). The `:` delimited key value mappings are deprecated and if provided will be translated to key=value. Likewise, if a wildcard is provided (e.g. `key:*`) it will be translated to just the standalone `key` which checks for key existence.
+
+These can be combined together, for example:
+```
+--namespace-selector=reloader:enabled,test:true
 ```
 
 Only namespaces labeled like the following namespace YAML will be watched:
@@ -195,7 +223,7 @@ apiVersion: v1
 metadata:
   ...
   labels:
-    reloder: enabled
+    reloader: enabled
     test: true
   ...
 ```
@@ -255,9 +283,15 @@ Reloader can be configured to ignore the resources `secrets` and `configmaps` by
 
 Reloader can be configured to watch only namespaces labeled with (one or more) labels of your choosing by using the `namespaceSelector` parameter
 
-| Parameter            | Description                                                    | Type    |
-| ----------------     | -------------------------------------------------------------- | ------- |
-| namespaceSelector    | list of comma separated key:value namespace                    | string  |
+| Parameter            | Description                                                                        | Type    |
+| ----------------     | ---------------------------------------------------------------------------------- | ------- |
+| namespaceSelector    | list of comma separated label selectors, if mulitple are provided they are ANDed   | string  |
+
+Reloader can be configured to watch only configmaps/secrets labeled with (one or more) labels of your choosing by using the `resourceLabelSelector` parameter
+
+| Parameter              | Description                                                                        | Type    |
+| ---------------------- | ---------------------------------------------------------------------------------- | ------- |
+| resourceLabelSelector  | list of comma separated label selectors, if mulitple are provided they are ANDed   | string  |
 
 You can also set the log format of Reloader to json by setting `logFormat` to `json` in values.yaml and apply the chart
 

--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -38,6 +38,8 @@ rules:
       - namespaces
     verbs:
       - get
+      - list
+      - watch
 {{- end }}
 {{- if and (.Capabilities.APIVersions.Has "apps.openshift.io/v1") (.Values.reloader.isOpenshift) }}
   - apiGroups:

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
           - mountPath: /tmp/
             name: tmp-volume
       {{- end }}
-      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.namespaceSelector) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) (eq .Values.reloader.isArgoRollouts true) (eq .Values.reloader.reloadOnCreate true) (ne .Values.reloader.reloadStrategy "default") (.Values.reloader.enableHA)}}
+      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.namespaceSelector) (.Values.reloader.resourceLabelSelector) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) (eq .Values.reloader.isArgoRollouts true) (eq .Values.reloader.reloadOnCreate true) (ne .Values.reloader.reloadStrategy "default") (.Values.reloader.enableHA)}}
         args:
           {{- if .Values.reloader.logFormat }}
           - "--log-format={{ .Values.reloader.logFormat }}"
@@ -175,7 +175,10 @@ spec:
           {{- end }}
           {{- if .Values.reloader.namespaceSelector }}
           - "--namespace-selector={{ .Values.reloader.namespaceSelector }}"
-          {{- end }}          
+          {{- end }}    
+          {{- if .Values.reloader.resourceLabelSelector }}
+          - "--resource-label-selector={{ .Values.reloader.resourceLabelSelector }}"
+          {{- end }}             
           {{- if .Values.reloader.custom_annotations }}
             {{- if .Values.reloader.custom_annotations.configmap }}
           - "--configmap-annotation"

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -20,8 +20,8 @@ reloader:
   syncAfterRestart: false
   reloadStrategy: default # Set to default, env-vars or annotations
   ignoreNamespaces: "" # Comma separated list of namespaces to ignore
-  namespaceSelector: "" # Comma separated list of 'key:value' labels for namespaces selection
-  resourceLabelSelector: "" # Comma separated list of 'key:value' labels for configmap/secret selection
+  namespaceSelector: "" # Comma separated list of k8s label selectors for namespaces selection
+  resourceLabelSelector: "" # Comma separated list of k8s label selectors for configmap/secret selection
   logFormat: "" #json
   watchGlobally: true
   # Set to true to enable leadership election allowing you to run multiple replicas

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -21,6 +21,7 @@ reloader:
   reloadStrategy: default # Set to default, env-vars or annotations
   ignoreNamespaces: "" # Comma separated list of namespaces to ignore
   namespaceSelector: "" # Comma separated list of 'key:value' labels for namespaces selection
+  resourceLabelSelector: "" # Comma separated list of 'key:value' labels for configmap/secret selection
   logFormat: "" #json
   watchGlobally: true
   # Set to true to enable leadership election allowing you to run multiple replicas

--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -148,7 +148,7 @@ func startReloader(cmd *cobra.Command, args []string) {
 
 	var controllers []*controller.Controller
 	for k := range kube.ResourceMap {
-		if ignoredResourcesList.Contains(k) {
+		if ignoredResourcesList.Contains(k) || (len(namespaceLabelSelector) == 0 && k == "namespaces") {
 			continue
 		}
 

--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stakater/Reloader/internal/pkg/util"
 	"github.com/stakater/Reloader/pkg/kube"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NewReloaderCommand starts the reloader controller
@@ -223,7 +224,7 @@ func getNamespaceLabelSelector(cmd *cobra.Command) (string, error) {
 	}
 
 	namespaceLabelSelector := strings.Join(slice[:], ",")
-	_, err = v1.ParseToLabelSelector(namespaceLabelSelector)
+	_, err = labels.Parse(namespaceLabelSelector)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -257,7 +258,7 @@ func getResourceLabelSelector(cmd *cobra.Command) (string, error) {
 	}
 
 	resourceLabelSelector := strings.Join(slice[:], ",")
-	_, err = v1.ParseToLabelSelector(resourceLabelSelector)
+	_, err = labels.Parse(resourceLabelSelector)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/internal/pkg/controller/controller.go
+++ b/internal/pkg/controller/controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/utils/strings/slices"
 )
 
 // Controller for checking events
@@ -41,6 +42,7 @@ type Controller struct {
 // controllerInitialized flag determines whether controlled is being initialized
 var secretControllerInitialized bool = false
 var configmapControllerInitialized bool = false
+var selectedNamespacesCache []string
 
 // NewController for initializing a Controller
 func NewController(
@@ -65,7 +67,17 @@ func NewController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("reloader-%s", resource)})
 
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	listWatcher := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), resource, namespace, fields.Everything())
+
+	optionsModifier := func(options *metav1.ListOptions) {
+		if resource == "namespaces" {
+			labelSelector := metav1.LabelSelector{MatchLabels: c.namespaceSelector}
+			options.LabelSelector = labels.Set(labelSelector.MatchLabels).String()
+		} else {
+			options.FieldSelector = fields.Everything().String()
+		}
+	}
+
+	listWatcher := cache.NewFilteredListWatchFromClient(client.CoreV1().RESTClient(), resource, namespace, optionsModifier)
 
 	indexer, informer := cache.NewIndexerInformer(listWatcher, kube.ResourceMap[resource], 0, cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.Add,
@@ -84,8 +96,15 @@ func NewController(
 
 // Add function to add a new object to the queue in case of creating a resource
 func (c *Controller) Add(obj interface{}) {
+
+	switch object := obj.(type) {
+	case *v1.Namespace:
+		c.addSelectedNamespaceToCache(object)
+		return
+	}
+
 	if options.ReloadOnCreate == "true" {
-		if !c.resourceInIgnoredNamespace(obj) && c.resourceInNamespaceSelector(obj) && secretControllerInitialized && configmapControllerInitialized {
+		if !c.resourceInIgnoredNamespace(obj) && c.resourceInSelectedNamespaces(obj) && secretControllerInitialized && configmapControllerInitialized {
 			c.queue.Add(handler.ResourceCreatedHandler{
 				Resource:   obj,
 				Collectors: c.collectors,
@@ -105,45 +124,45 @@ func (c *Controller) resourceInIgnoredNamespace(raw interface{}) bool {
 	return false
 }
 
-func (c *Controller) resourceInNamespaceSelector(raw interface{}) bool {
+func (c *Controller) resourceInSelectedNamespaces(raw interface{}) bool {
 	if len(c.namespaceSelector) == 0 {
 		return true
 	}
 
 	switch object := raw.(type) {
 	case *v1.ConfigMap:
-		return c.matchLabels(object.ObjectMeta.Namespace)
+		if slices.Contains(selectedNamespacesCache, object.GetNamespace()) {
+			return true
+		}
 	case *v1.Secret:
-		return c.matchLabels(object.ObjectMeta.Namespace)
+		if slices.Contains(selectedNamespacesCache, object.GetNamespace()) {
+			return true
+		}
 	}
-	return true
+	return false
 }
 
-func (c *Controller) matchLabels(resourceNamespace string) bool {
-	namespace, err := c.client.CoreV1().Namespaces().Get(context.Background(), resourceNamespace, metav1.GetOptions{})
-	if err != nil {
-		logrus.Warn(err)
-		return false
-	}
+func (c *Controller) addSelectedNamespaceToCache(namespace *v1.Namespace) {
+	selectedNamespacesCache = append(selectedNamespacesCache, namespace.GetName())
+}
 
-	for selectorKey, selectorVal := range c.namespaceSelector {
-
-		namespaceLabelVal, namespaceLabelKeyExists := namespace.ObjectMeta.Labels[selectorKey]
-
-		if namespaceLabelKeyExists && selectorVal == "*" {
-			continue
-		}
-
-		if !namespaceLabelKeyExists || selectorVal != namespaceLabelVal {
-			return false
+func (c *Controller) removeSelectedNamespaceFromCache(namespace *v1.Namespace) {
+	for i, v := range selectedNamespacesCache {
+		if v == namespace.GetName() {
+			selectedNamespacesCache = append(selectedNamespacesCache[:i], selectedNamespacesCache[i+1:]...)
+			return
 		}
 	}
-	return true
 }
 
 // Update function to add an old object and a new object to the queue in case of updating a resource
 func (c *Controller) Update(old interface{}, new interface{}) {
-	if !c.resourceInIgnoredNamespace(new) && c.resourceInNamespaceSelector(new) {
+	switch new.(type) {
+	case *v1.Namespace:
+		return
+	}
+
+	if !c.resourceInIgnoredNamespace(new) && c.resourceInSelectedNamespaces(new) {
 		c.queue.Add(handler.ResourceUpdatedHandler{
 			Resource:    new,
 			OldResource: old,
@@ -155,6 +174,12 @@ func (c *Controller) Update(old interface{}, new interface{}) {
 
 // Delete function to add an object to the queue in case of deleting a resource
 func (c *Controller) Delete(old interface{}) {
+	switch object := old.(type) {
+	case *v1.Namespace:
+		c.removeSelectedNamespaceFromCache(object)
+		return
+	}
+
 	// Todo: Any future delete event can be handled here
 }
 

--- a/internal/pkg/controller/controller_test.go
+++ b/internal/pkg/controller/controller_test.go
@@ -45,6 +45,9 @@ func TestMain(m *testing.M) {
 
 	logrus.Infof("Creating controller")
 	for k := range kube.ResourceMap {
+		if k == "namespaces" {
+			continue
+		}
 		c, err := NewController(clients.KubernetesClient, k, namespace, []string{}, "", "", collectors)
 		if err != nil {
 			logrus.Fatalf("%s", err)

--- a/internal/pkg/leadership/leadership_test.go
+++ b/internal/pkg/leadership/leadership_test.go
@@ -119,7 +119,7 @@ func TestRunLeaderElectionWithControllers(t *testing.T) {
 	t.Logf("Creating controller")
 	var controllers []*controller.Controller
 	for k := range kube.ResourceMap {
-		c, err := controller.NewController(testutil.Clients.KubernetesClient, k, testutil.Namespace, []string{}, map[string]string{}, map[string]string{}, metrics.NewCollectors())
+		c, err := controller.NewController(testutil.Clients.KubernetesClient, k, testutil.Namespace, []string{}, "", "", metrics.NewCollectors())
 		if err != nil {
 			logrus.Fatalf("%s", err)
 		}

--- a/internal/pkg/leadership/leadership_test.go
+++ b/internal/pkg/leadership/leadership_test.go
@@ -119,7 +119,7 @@ func TestRunLeaderElectionWithControllers(t *testing.T) {
 	t.Logf("Creating controller")
 	var controllers []*controller.Controller
 	for k := range kube.ResourceMap {
-		c, err := controller.NewController(testutil.Clients.KubernetesClient, k, testutil.Namespace, []string{}, map[string]string{}, metrics.NewCollectors())
+		c, err := controller.NewController(testutil.Clients.KubernetesClient, k, testutil.Namespace, []string{}, map[string]string{}, map[string]string{}, metrics.NewCollectors())
 		if err != nil {
 			logrus.Fatalf("%s", err)
 		}

--- a/pkg/kube/resourcemapper.go
+++ b/pkg/kube/resourcemapper.go
@@ -9,4 +9,5 @@ import (
 var ResourceMap = map[string]runtime.Object{
 	"configMaps": &v1.ConfigMap{},
 	"secrets":    &v1.Secret{},
+	"namespaces":    &v1.Namespace{},
 }


### PR DESCRIPTION
Signed-off-by: Craig Trought <k8s@trought.ca>

**What does this PR do?**
This PR refactors the `--namespace-selector` option to also use an informer cache controller with a labelSelector. These are stored in a simple slice and a lookup is performed to check if the configmap/secret is in one of the selected namespaces instead of fetching the updated objects namespace and iterating over the labels to do the comparison.

It also adds a new flag `--resource-label-selector` which applies a similar label selector on the configmap/secret informer controller.

Because these both use a native k8s labelSelector, all the native operators are supported `!, in, notin, ==, =, !=` and "exists" is implied when only the key is provided which provides more complex select capabilities. The original implementation used `:` delimited fields, so it is easy enough to convert to standard `key=value` for backwards compatibility which is handled when the flag is processed on startup, and for wildcard values to the standalone key. I've added a note that says those forms would be deprecated in favour of the standard k8s label selector syntax, but of course can change this to however the maintainers would prefer to handle.

**Why do we need it?**
When using the `--namespace-selector` flag and global mode, in large clusters any configmap/secret update triggers a call to fetch the namespace of the object to do the label comparison. This is can trigger tens of thousands of GET requests for namespaces per hour and can result in poor performance & throttling, especially if there are many configmap/secret updates in the larger cluster. In my case, the reloads on workloads were missed entirely in these enabled namespaces as seen in #424.

Tracking the API calls to `v1.namespaces` when enabling namespaceSelector, over a 1 hour period in a cluster with 600 namespaces, 15000 configmaps, and 20000 secrets with only 5 namespaces enabled.

Before (5 requests/second)
```
REQUESTSINCURRENTHOUR     VERBS         USER 
17785                     get           system:serviceaccount:reloader:reloader-reloader                                                               manager/v0.0.0
```

After (1 watch, local cache updated on changes)
```
REQUESTSINCURRENTHOUR     VERBS         USER 
1                         watch         system:serviceaccount:reloader:reloader-reloader                                                               manager/v0.0.0
```

The reason behind `--resource-label-selector` is in a large cluster with thousands of configmaps & secrets, reloader will watch all secrets & configmaps even though I as a user may only care about a specific set across a handful of namespaces. This is true even when `namespaceSelector` is enabled because all configmaps/secrets are currently still watched, and the filtering is applied after the configmap/secret the update event has been received to exclude it from reload events. While functionally it works, there can be a significant resource overhead when performing the global watch without any selector even though I as a user may only care to enable the reload functionality on 1% of the configmaps/secrets in the cluster, while the other 99% still need some processing performed the controller needs increased resources to handle that additional processing. 

In the cluster with the same specs provided (600 namespaces, 15000 configmaps, and 20000 secrets with only 5 namespaces enabled), the controller requires over 12 GB of memory after bumping from 4 to 8 to 12 GB but I was still occasionally hitting OOM events. After configuring the proposed label selectors, resource usage was down to ~50 MB. Of course with my current setup/testing, initially we only have a small number of namespaces and configmaps/secrets enabled so it will still scale linearly. Even as this grows we will still benefit from the resources that would no longer watched by default (ie. it will be opt-in)

These two options provide help provide more granular controls to the cluster admins wishing the scope down reloader targets for performance reasons and resource optimization. 

Before / After Memory
<img width="1120" alt="image" src="https://user-images.githubusercontent.com/65360454/229337455-2b11ad1b-ae62-4fca-8800-2f7677f5f9d2.png">

Before / After CPU
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/65360454/229337509-edad44d7-b61a-41f2-a86d-a92902933c3e.png">


**Notes:**
Thought of maybe doing individual label selector flags for configmap & secrets, but wasn't sure how much use there would be. I figure most who choose to enable this would end up applying the same labels to both.

Fixes: #424