### PR TITLE
Update Go setup for GitHub Actions workflows

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,31 +7,31 @@ on:
 
 env:
   DOCKER_FILE_PATH: Dockerfile
-  GOLANG_VERSION: 1.20.3
   KUBERNETES_VERSION: "1.18.0"
   KIND_VERSION: "0.10.0"
   REGISTRY: ghcr.io
 
 jobs:
   build:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     name: Build
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"    
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
     - name: Check out code
       uses: actions/checkout@v3
       with:
         ref: ${{github.event.pull_request.head.sha}}
-        
+
     # Setting up helm binary
     - name: Set up Helm
       uses: azure/setup-helm@v3
 
     - name: Set up Go
-      id: go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ env.GOLANG_VERSION }}
+        go-version-file: 'go.mod'
+        check-latest: true
+        cache: true
 
     - name: Install Dependencies
       run: |
@@ -70,7 +70,7 @@ jobs:
       run: |
         kind create cluster
         kubectl cluster-info
-        
+
     - name: Test
       run: make test
 
@@ -80,7 +80,7 @@ jobs:
         sha=${{ github.event.pull_request.head.sha }}
         tag="SNAPSHOT-PR-${{ github.event.pull_request.number }}-${sha:0:8}"
         echo "##[set-output name=GIT_TAG;]$(echo ${tag})"
-    
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   DOCKER_FILE_PATH: Dockerfile
-  GOLANG_VERSION: 1.20.3
   KUBERNETES_VERSION: "1.18.0"
   KIND_VERSION: "0.10.0"
   HELM_REGISTRY_URL: "https://stakater.github.io/stakater-charts"
@@ -31,10 +30,11 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Set up Go
-        id: go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GOLANG_VERSION }}
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: true
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v*"
 
-env:
-  GOLANG_VERSION: 1.20.3
-
 jobs:
   build:
     name: GoReleaser build
@@ -19,11 +16,12 @@ jobs:
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GOLANG_VERSION }}
-        id: go
+          go-version-file: "go.mod"
+          check-latest: true
+          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@master


### PR DESCRIPTION
1. Upgrades `actions/setup-go` to v4
2. `actions/setup-go@v4` has the ability to get the go version directly from `go.mod`. This removes the duplication of go version in multiple places
3. Enables caching of the go step, speeds up setup