### PR TITLE
Remove v version prefix from helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ deploy: binary-image push apply
 
 # Bump Chart
 bump-chart: 
-	sed -i "s/^version:.*/version: v$(VERSION)/" deployments/kubernetes/chart/reloader/Chart.yaml
+	sed -i "s/^version:.*/version: $(VERSION)/" deployments/kubernetes/chart/reloader/Chart.yaml
 	sed -i "s/^appVersion:.*/appVersion: v$(VERSION)/" deployments/kubernetes/chart/reloader/Chart.yaml
 	sed -i "s/tag:.*/tag: v$(VERSION)/" deployments/kubernetes/chart/reloader/values.yaml
 	sed -i "s/version:.*/version: v$(VERSION)/" deployments/kubernetes/chart/reloader/values.yaml

--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: v1.0.24
+version: 1.0.24
 appVersion: v1.0.24
 keywords:
   - Reloader


### PR DESCRIPTION
Hi there,

i would suggest to remove the version prefix from the helm chart.

The [Chart.yaml](https://helm.sh/docs/topics/charts/#the-chartyaml-file) spec requires a [SemVer v2](https://helm.sh/docs/topics/charts/#charts-and-versioning) compatible version on the `version` field. Having a v in front makes the field from technical point of view invalid.

Jetbrains IDEs raise errors, too:

![image](https://github.com/stakater/Reloader/assets/1560587/b850923b-070f-43ba-a975-ebf07903b4c0)

Mention that `appVersion` can have any string value. Using a v in front is fine there.
