### PR TITLE
[SECURITY] bump go version (CVE-2023-24540, CVE-2023-29400, CVE-2023-24539)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE
 ARG BASE_IMAGE
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.20.3} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.20.4} as builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Bump go version to 1.20.4. This will fix these findings:

- CVE-2023-24540
- CVE-2023-29400
- CVE-2023-24539

Would be nice to have some bot like renovate configured to create this kind of PRs automaticly.