### PR TITLE
feat: add optional networkpolicy to helm-chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _gopath/
 vendor
 dist
 Reloader
+!**/chart/reloader

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if and ( .Values.reloader.netpol.enabled ) }}
+kubectlapiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+{{ include "reloader-helm3.annotations" . | indent 4 }}
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "reloader-fullname" . }}
+      release: {{ .Release.Name | quote }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 6 }}
+{{- end }}
+  policyTypes:
+  - Ingress
+  ingress:
+    - ports:
+        - port: http
+      {{- with .Values.reloader.netpol.from}}
+      from:
+        {{- toYaml .| nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- if and ( .Values.reloader.netpol.enabled ) }}
-kubectlapiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   annotations:

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -268,3 +268,10 @@ reloader:
     enabled: false
     # Set the minimum available replicas
     # minAvailable: 1
+
+  netpol:
+    enabled: false
+    from: []
+    # - podSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/name: prometheus


### PR DESCRIPTION
Add an optional NetworkPolicy to the helm-chart to allow ingress-traffic to http-port.

Fixes #448 