### PR TITLE
Add --auto-reload-all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ not.
 We can also specify a specific configmap or secret which would trigger rolling upgrade only upon change in our specified configmap or secret, this way, it will not trigger rolling upgrade upon changes in all configmaps or secrets used in a `deploymentconfig`, `deployment`, `daemonset`, `statefulset` or `rollout`.
 To do this either set the auto annotation to `"false"` (`reloader.stakater.com/auto: "false"`) or remove it altogether, and use annotations for [Configmap](.#Configmap) or [Secret](.#Secret).
 
+It's also possible to enable auto reloading for all resources, by setting the `--auto-reload-all` flag.
+In this case, all resources that do not have the auto annotation set to `"false"`, will be reloaded automatically when their ConfigMaps or Secrets are updated.
+Notice that setting the auto annotation to an undefined value counts as false as-well.
+
 ### Configmap
 
 To perform rolling upgrade when change happens only on specific configmaps use below annotation.

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
           - mountPath: /tmp/
             name: tmp-volume
       {{- end }}
-      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.namespaceSelector) (.Values.reloader.resourceLabelSelector) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) (eq .Values.reloader.isArgoRollouts true) (eq .Values.reloader.reloadOnCreate true) (ne .Values.reloader.reloadStrategy "default") (.Values.reloader.enableHA)}}
+      {{- if or (.Values.reloader.logFormat) (.Values.reloader.ignoreSecrets) (.Values.reloader.ignoreNamespaces) (.Values.reloader.namespaceSelector) (.Values.reloader.resourceLabelSelector) (.Values.reloader.ignoreConfigMaps) (.Values.reloader.custom_annotations) (eq .Values.reloader.isArgoRollouts true) (eq .Values.reloader.reloadOnCreate true) (ne .Values.reloader.reloadStrategy "default") (.Values.reloader.enableHA) (.Values.reloader.autoReloadAll)}}
         args:
           {{- if .Values.reloader.logFormat }}
           - "--log-format={{ .Values.reloader.logFormat }}"
@@ -222,6 +222,9 @@ spec:
           {{- if or (gt (int .Values.reloader.deployment.replicas) 1) (.Values.reloader.enableHA) }}
           - "--enable-ha=true"
           {{- end}}
+          {{- if eq .Values.reloader.autoReloadAll true }}
+          - "--auto-reload-all=true"
+          {{- end -}}
       {{- end }}
       {{- if .Values.reloader.deployment.resources }}
         resources:

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -12,6 +12,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 reloader:
+  autoReloadAll: false
   isArgoRollouts: false
   isOpenshift: false
   ignoreSecrets: false

--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -32,6 +32,7 @@ func NewReloaderCommand() *cobra.Command {
 	}
 
 	// options
+	cmd.PersistentFlags().BoolVar(&options.AutoReloadAll, "auto-reload-all", false, "Auto reload all resources")
 	cmd.PersistentFlags().StringVar(&options.ConfigmapUpdateOnChangeAnnotation, "configmap-annotation", "configmap.reloader.stakater.com/reload", "annotation to detect changes in configmaps, specified by name")
 	cmd.PersistentFlags().StringVar(&options.SecretUpdateOnChangeAnnotation, "secret-annotation", "secret.reloader.stakater.com/reload", "annotation to detect changes in secrets, specified by name")
 	cmd.PersistentFlags().StringVar(&options.ReloaderAutoAnnotation, "auto-annotation", "reloader.stakater.com/auto", "annotation to detect changes in secrets")

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -154,7 +154,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 		}
 		result := constants.NotUpdated
 		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
-		if err == nil && (reloaderEnabled || options.AutoReloadAll) {
+		if (reloaderEnabledValue == "" || err == nil) && (reloaderEnabled || options.AutoReloadAll) {
 			result = invokeReloadStrategy(upgradeFuncs, i, config, true)
 		}
 

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -153,8 +153,8 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 			reloaderEnabledValue = annotations[options.ReloaderAutoAnnotation]
 		}
 		result := constants.NotUpdated
-		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
-		if (reloaderEnabledValue == "" || err == nil) && (reloaderEnabled || options.AutoReloadAll) {
+		reloaderEnabled, _ := strconv.ParseBool(reloaderEnabledValue)
+		if reloaderEnabled || reloaderEnabledValue == "" && options.AutoReloadAll {
 			result = invokeReloadStrategy(upgradeFuncs, i, config, true)
 		}
 

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -154,7 +154,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 		}
 		result := constants.NotUpdated
 		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
-		if (err != nil && options.AutoReloadAll) || (err == nil && (reloaderEnabled || options.AutoReloadAll)) {
+		if err == nil && (reloaderEnabled || options.AutoReloadAll) {
 			result = invokeReloadStrategy(upgradeFuncs, i, config, true)
 		}
 

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -153,8 +153,9 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 			reloaderEnabledValue = annotations[options.ReloaderAutoAnnotation]
 		}
 		result := constants.NotUpdated
-		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
-		if err == nil && reloaderEnabled {
+		reloaderEnabled, _ := strconv.ParseBool(reloaderEnabledValue)
+		reloaderEnabled = reloaderEnabled && foundAuto || !foundAuto && options.AutoReloadAll
+		if reloaderEnabled {
 			result = invokeReloadStrategy(upgradeFuncs, i, config, true)
 		}
 

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -153,9 +153,8 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 			reloaderEnabledValue = annotations[options.ReloaderAutoAnnotation]
 		}
 		result := constants.NotUpdated
-		reloaderEnabled, _ := strconv.ParseBool(reloaderEnabledValue)
-		reloaderEnabled = reloaderEnabled && foundAuto || !foundAuto && options.AutoReloadAll
-		if reloaderEnabled {
+		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
+		if (err != nil && options.AutoReloadAll) || (err == nil && (reloaderEnabled || options.AutoReloadAll)) {
 			result = invokeReloadStrategy(upgradeFuncs, i, config, true)
 		}
 

--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -43,6 +43,7 @@ var (
 	arsConfigmapWithPodAnnotations         = "testconfigmapPodAnnotations-handler-" + testutil.RandSeq(5)
 	arsConfigmapWithBothAnnotations        = "testconfigmapBothAnnotations-handler-" + testutil.RandSeq(5)
 	arsConfigmapAnnotated                  = "testconfigmapAnnotated-handler-" + testutil.RandSeq(5)
+	arsConfigMapWithNonAnnotatedDeployment = "testconfigmapNonAnnotatedDeployment-handler-" + testutil.RandSeq(5)
 
 	ersNamespace                           = "test-handler-" + testutil.RandSeq(5)
 	ersConfigmapName                       = "testconfigmap-handler-" + testutil.RandSeq(5)
@@ -173,6 +174,11 @@ func setupArs() {
 		logrus.Errorf("Error in configmap creation: %v", err)
 	}
 
+	_, err = testutil.CreateConfigMap(clients.KubernetesClient, arsNamespace, arsConfigMapWithNonAnnotatedDeployment, "www.google.com")
+	if err != nil {
+		logrus.Errorf("Error in configmap creation: %v", err)
+	}
+
 	// Creating Deployment with configmap
 	_, err = testutil.CreateDeployment(clients.KubernetesClient, arsConfigmapName, arsNamespace, true)
 	if err != nil {
@@ -266,6 +272,12 @@ func setupArs() {
 	)
 	if err != nil {
 		logrus.Errorf("Error in Deployment with secret configmap as envFrom source creation: %v", err)
+	}
+
+	// Creating Deployment with configmap and without annotations
+	_, err = testutil.CreateDeploymentWithoutAnnotations(clients.KubernetesClient, arsConfigMapWithNonAnnotatedDeployment, arsNamespace)
+	if err != nil {
+		logrus.Errorf("Error in Deployment with configmap and without annotation creation: %v", err)
 	}
 
 	// Creating DaemonSet with configmap
@@ -1202,6 +1214,86 @@ func TestRollingUpgradeForDeploymentWithConfigmapUsingArs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+}
+
+func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationAndWithoutAutoReloadAllNoTriggersUsingArs(t *testing.T) {
+	options.ReloadStrategy = constants.AnnotationsReloadStrategy
+
+	shaData := testutil.ConvertResourceToSHA(testutil.ConfigmapResourceType, arsNamespace, arsConfigMapWithNonAnnotatedDeployment, "www.stakater.com")
+	config := getConfigWithAnnotations(constants.ConfigmapEnvVarPostfix, arsConfigMapWithNonAnnotatedDeployment, shaData, options.ConfigmapUpdateOnChangeAnnotation)
+	deploymentFuncs := GetDeploymentRollingUpgradeFuncs()
+	collectors := getCollectors()
+
+	err := PerformRollingUpgrade(clients, config, deploymentFuncs, collectors, nil)
+	time.Sleep(5 * time.Second)
+	if err != nil {
+		t.Errorf("Rolling upgrade failed for Deployment with Configmap")
+	}
+
+	logrus.Infof("Verifying deployment update")
+	updated := testutil.VerifyResourceAnnotationUpdate(clients, config, deploymentFuncs)
+	if updated {
+		t.Errorf("Deployment was updated")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
+		t.Errorf("Counter was increased")
+	}
+}
+
+func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationButWithAutoReloadAllUsingArs(t *testing.T) {
+	options.ReloadStrategy = constants.AnnotationsReloadStrategy
+	options.AutoReloadAll = true
+	defer func() { options.AutoReloadAll = false }()
+
+	shaData := testutil.ConvertResourceToSHA(testutil.ConfigmapResourceType, arsNamespace, arsConfigMapWithNonAnnotatedDeployment, "www.stakater.com")
+	config := getConfigWithAnnotations(constants.ConfigmapEnvVarPostfix, arsConfigMapWithNonAnnotatedDeployment, shaData, "")
+	deploymentFuncs := GetDeploymentRollingUpgradeFuncs()
+	collectors := getCollectors()
+
+	err := PerformRollingUpgrade(clients, config, deploymentFuncs, collectors, nil)
+	time.Sleep(5 * time.Second)
+	if err != nil {
+		t.Errorf("Rolling upgrade failed for Deployment with Configmap")
+	}
+
+	logrus.Infof("Verifying deployment update")
+	updated := testutil.VerifyResourceAnnotationUpdate(clients, config, deploymentFuncs)
+	if !updated {
+		t.Errorf("Deployment was not updated")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
+		t.Errorf("Counter was not increased")
+	}
+}
+
+func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationAndAutoReloadAllSetToTrueNoTriggersUsingArs(t *testing.T) {
+	options.ReloadStrategy = constants.AnnotationsReloadStrategy
+	options.AutoReloadAll = true
+	defer func() { options.AutoReloadAll = false }()
+
+	shaData := testutil.ConvertResourceToSHA(testutil.ConfigmapResourceType, arsNamespace, arsConfigmapAnnotated, "www.stakater.com")
+	config := getConfigWithAnnotations(constants.ConfigmapEnvVarPostfix, arsConfigmapAnnotated, shaData, "")
+	config.ResourceAnnotations = map[string]string{"reloader.stakater.com/match": "false"}
+	deploymentFuncs := GetDeploymentRollingUpgradeFuncs()
+	collectors := getCollectors()
+
+	err := PerformRollingUpgrade(clients, config, deploymentFuncs, collectors, nil)
+	if err != nil {
+		t.Errorf("Rolling upgrade failed for Deployment with Configmap")
+	}
+
+	logrus.Infof("Verifying deployment update")
+	updated := testutil.VerifyResourceAnnotationUpdate(clients, config, deploymentFuncs)
+	time.Sleep(5 * time.Second)
+	if updated {
+		t.Errorf("Deployment was updated unexpectedly")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
+		t.Errorf("Counter was increased unexpectedly")
 	}
 }
 

--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -25,26 +25,25 @@ import (
 var (
 	clients = kube.Clients{KubernetesClient: testclient.NewSimpleClientset()}
 
-	arsNamespace                               = "test-handler-" + testutil.RandSeq(5)
-	arsConfigmapName                           = "testconfigmap-handler-" + testutil.RandSeq(5)
-	arsSecretName                              = "testsecret-handler-" + testutil.RandSeq(5)
-	arsProjectedConfigMapName                  = "testprojectedconfigmap-handler-" + testutil.RandSeq(5)
-	arsProjectedSecretName                     = "testprojectedsecret-handler-" + testutil.RandSeq(5)
-	arsConfigmapWithInitContainer              = "testconfigmapInitContainerhandler-" + testutil.RandSeq(5)
-	arsSecretWithInitContainer                 = "testsecretWithInitContainer-handler-" + testutil.RandSeq(5)
-	arsProjectedConfigMapWithInitContainer     = "testProjectedConfigMapWithInitContainer-handler" + testutil.RandSeq(5)
-	arsProjectedSecretWithInitContainer        = "testProjectedSecretWithInitContainer-handler" + testutil.RandSeq(5)
-	arsConfigmapWithInitEnv                    = "configmapWithInitEnv-" + testutil.RandSeq(5)
-	arsSecretWithInitEnv                       = "secretWithInitEnv-handler-" + testutil.RandSeq(5)
-	arsConfigmapWithEnvName                    = "testconfigmapWithEnv-handler-" + testutil.RandSeq(5)
-	arsConfigmapWithEnvFromName                = "testconfigmapWithEnvFrom-handler-" + testutil.RandSeq(5)
-	arsSecretWithEnvName                       = "testsecretWithEnv-handler-" + testutil.RandSeq(5)
-	arsSecretWithEnvFromName                   = "testsecretWithEnvFrom-handler-" + testutil.RandSeq(5)
-	arsConfigmapWithPodAnnotations             = "testconfigmapPodAnnotations-handler-" + testutil.RandSeq(5)
-	arsConfigmapWithBothAnnotations            = "testconfigmapBothAnnotations-handler-" + testutil.RandSeq(5)
-	arsConfigmapAnnotated                      = "testconfigmapAnnotated-handler-" + testutil.RandSeq(5)
-	arsConfigMapWithNonAnnotatedDeployment     = "testconfigmapNonAnnotatedDeployment-handler-" + testutil.RandSeq(5)
-	arsConfigMapWithDeploymentReloadSetToFalse = "testconfigMapWithDeploymentReloadSetToFalse-handler-" + testutil.RandSeq(5)
+	arsNamespace                           = "test-handler-" + testutil.RandSeq(5)
+	arsConfigmapName                       = "testconfigmap-handler-" + testutil.RandSeq(5)
+	arsSecretName                          = "testsecret-handler-" + testutil.RandSeq(5)
+	arsProjectedConfigMapName              = "testprojectedconfigmap-handler-" + testutil.RandSeq(5)
+	arsProjectedSecretName                 = "testprojectedsecret-handler-" + testutil.RandSeq(5)
+	arsConfigmapWithInitContainer          = "testconfigmapInitContainerhandler-" + testutil.RandSeq(5)
+	arsSecretWithInitContainer             = "testsecretWithInitContainer-handler-" + testutil.RandSeq(5)
+	arsProjectedConfigMapWithInitContainer = "testProjectedConfigMapWithInitContainer-handler" + testutil.RandSeq(5)
+	arsProjectedSecretWithInitContainer    = "testProjectedSecretWithInitContainer-handler" + testutil.RandSeq(5)
+	arsConfigmapWithInitEnv                = "configmapWithInitEnv-" + testutil.RandSeq(5)
+	arsSecretWithInitEnv                   = "secretWithInitEnv-handler-" + testutil.RandSeq(5)
+	arsConfigmapWithEnvName                = "testconfigmapWithEnv-handler-" + testutil.RandSeq(5)
+	arsConfigmapWithEnvFromName            = "testconfigmapWithEnvFrom-handler-" + testutil.RandSeq(5)
+	arsSecretWithEnvName                   = "testsecretWithEnv-handler-" + testutil.RandSeq(5)
+	arsSecretWithEnvFromName               = "testsecretWithEnvFrom-handler-" + testutil.RandSeq(5)
+	arsConfigmapWithPodAnnotations         = "testconfigmapPodAnnotations-handler-" + testutil.RandSeq(5)
+	arsConfigmapWithBothAnnotations        = "testconfigmapBothAnnotations-handler-" + testutil.RandSeq(5)
+	arsConfigmapAnnotated                  = "testconfigmapAnnotated-handler-" + testutil.RandSeq(5)
+	arsConfigMapWithNonAnnotatedDeployment = "testconfigmapNonAnnotatedDeployment-handler-" + testutil.RandSeq(5)
 
 	ersNamespace                           = "test-handler-" + testutil.RandSeq(5)
 	ersConfigmapName                       = "testconfigmap-handler-" + testutil.RandSeq(5)
@@ -180,11 +179,6 @@ func setupArs() {
 		logrus.Errorf("Error in configmap creation: %v", err)
 	}
 
-	_, err = testutil.CreateConfigMap(clients.KubernetesClient, arsNamespace, arsConfigMapWithDeploymentReloadSetToFalse, "www.google.com")
-	if err != nil {
-		logrus.Errorf("Error in configmap creation: %v", err)
-	}
-
 	// Creating Deployment with configmap
 	_, err = testutil.CreateDeployment(clients.KubernetesClient, arsConfigmapName, arsNamespace, true)
 	if err != nil {
@@ -275,17 +269,6 @@ func setupArs() {
 		arsConfigmapAnnotated,
 		arsNamespace,
 		map[string]string{"reloader.stakater.com/search": "true"},
-	)
-	if err != nil {
-		logrus.Errorf("Error in Deployment with secret configmap as envFrom source creation: %v", err)
-	}
-
-	// Creating Deployment with envFrom source as secret
-	_, err = testutil.CreateDeploymentWithEnvVarSourceAndAnnotations(
-		clients.KubernetesClient,
-		arsConfigMapWithDeploymentReloadSetToFalse,
-		arsNamespace,
-		map[string]string{options.ReloaderAutoAnnotation: "false"},
 	)
 	if err != nil {
 		logrus.Errorf("Error in Deployment with secret configmap as envFrom source creation: %v", err)
@@ -1284,33 +1267,6 @@ func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationButWithA
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
-	}
-}
-
-func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationAndAutoReloadAllSetToTrueNoTriggersUsingArs(t *testing.T) {
-	options.ReloadStrategy = constants.AnnotationsReloadStrategy
-	options.AutoReloadAll = true
-	defer func() { options.AutoReloadAll = false }()
-
-	shaData := testutil.ConvertResourceToSHA(testutil.ConfigmapResourceType, arsNamespace, arsConfigMapWithDeploymentReloadSetToFalse, "www.stakater.com")
-	config := getConfigWithAnnotations(constants.ConfigmapEnvVarPostfix, arsConfigMapWithDeploymentReloadSetToFalse, shaData, options.ReloaderAutoAnnotation)
-	deploymentFuncs := GetDeploymentRollingUpgradeFuncs()
-	collectors := getCollectors()
-
-	err := PerformRollingUpgrade(clients, config, deploymentFuncs, collectors, nil)
-	if err != nil {
-		t.Errorf("Rolling upgrade failed for Deployment with Configmap")
-	}
-
-	logrus.Infof("Verifying deployment update")
-	updated := testutil.VerifyResourceAnnotationUpdate(clients, config, deploymentFuncs)
-	time.Sleep(5 * time.Second)
-	if updated {
-		t.Errorf("Deployment was updated unexpectedly")
-	}
-
-	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
-		t.Errorf("Counter was increased unexpectedly")
 	}
 }
 

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -3,6 +3,8 @@ package options
 import "github.com/stakater/Reloader/internal/pkg/constants"
 
 var (
+	// Auto reload all resources when their corresponding configmaps/secrets are updated
+	AutoReloadAll = false
 	// ConfigmapUpdateOnChangeAnnotation is an annotation to detect changes in
 	// configmaps specified by name
 	ConfigmapUpdateOnChangeAnnotation = "configmap.reloader.stakater.com/reload"

--- a/internal/pkg/testutil/kube.go
+++ b/internal/pkg/testutil/kube.go
@@ -78,6 +78,15 @@ func getObjectMeta(namespace string, name string, autoReload bool) metav1.Object
 	}
 }
 
+func getObjectMetaWithoutAnnotations(namespace string, name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:        name,
+		Namespace:   namespace,
+		Labels:      map[string]string{"firstLabel": "temp"},
+		Annotations: map[string]string{},
+	}
+}
+
 func getAnnotations(name string, autoReload bool) map[string]string {
 	if autoReload {
 		return map[string]string{
@@ -333,6 +342,23 @@ func GetDeployment(namespace string, deploymentName string) *appsv1.Deployment {
 	replicaset := int32(1)
 	return &appsv1.Deployment{
 		ObjectMeta: getObjectMeta(namespace, deploymentName, false),
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"secondLabel": "temp"},
+			},
+			Replicas: &replicaset,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			Template: getPodTemplateSpecWithVolumes(deploymentName),
+		},
+	}
+}
+
+func getDeploymentWithoutAnnotations(namespace string, deploymentName string) *appsv1.Deployment {
+	replicaset := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: getObjectMetaWithoutAnnotations(namespace, deploymentName),
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"secondLabel": "temp"},
@@ -666,6 +692,16 @@ func CreateDeployment(client kubernetes.Interface, deploymentName string, namesp
 	return deployment, err
 }
 
+// CreateDeployment creates a deployment in given namespace and returns the Deployment
+func CreateDeploymentWithoutAnnotations(client kubernetes.Interface, deploymentName string, namespace string) (*appsv1.Deployment, error) {
+	logrus.Infof("Creating Deployment without annotations")
+	deploymentClient := client.AppsV1().Deployments(namespace)
+	deploymentObj := getDeploymentWithoutAnnotations(namespace, deploymentName)
+	deployment, err := deploymentClient.Create(context.TODO(), deploymentObj, metav1.CreateOptions{})
+	time.Sleep(3 * time.Second)
+	return deployment, err
+}
+
 // CreateDeploymentConfig creates a deploymentConfig in given namespace and returns the DeploymentConfig
 func CreateDeploymentConfig(client appsclient.Interface, deploymentName string, namespace string, volumeMount bool) (*openshiftv1.DeploymentConfig, error) {
 	logrus.Infof("Creating DeploymentConfig")
@@ -892,6 +928,7 @@ func VerifyResourceEnvVarUpdate(clients kube.Clients, config util.Config, envVar
 func VerifyResourceAnnotationUpdate(clients kube.Clients, config util.Config, upgradeFuncs callbacks.RollingUpgradeFuncs) bool {
 	items := upgradeFuncs.ItemsFunc(clients, config.Namespace)
 	for _, i := range items {
+		logrus.Printf("Items iteration")
 		podAnnotations := upgradeFuncs.PodAnnotationsFunc(i)
 		accessor, err := meta.Accessor(i)
 		if err != nil {
@@ -904,7 +941,7 @@ func VerifyResourceAnnotationUpdate(clients kube.Clients, config util.Config, up
 		reloaderEnabledValue := annotations[options.ReloaderAutoAnnotation]
 		reloaderEnabled, err := strconv.ParseBool(reloaderEnabledValue)
 		matches := false
-		if err == nil && reloaderEnabled {
+		if (reloaderEnabledValue == "" || err == nil) && (reloaderEnabled || options.AutoReloadAll) {
 			matches = true
 		} else if annotationValue != "" {
 			values := strings.Split(annotationValue, ",")


### PR DESCRIPTION
This is my PR for issue #478.
I added the flag `--auto-reload-all`, which commands the controller to reload all resources when their configmaps/secrets change, unless they have the `auto` annotation set to `false` (or an undefined value).
I'd be glad to get feedback on this, so please tell me if the documentation isn't clear enough, or if you think this should be implemented differently.