### PR TITLE
#491 Readme: Add OpenShift 4.13 runAsUser unset part

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ You can enable to scrape Reloader's Prometheus metrics by setting `serviceMonito
 | reloadOnCreate   | Enable reload on create events. Valid value are either `true` or `false`                                                                 | boolean |
 | syncAfterRestart | Enable sync after Reloader restarts for **Add** events, works only when reloadOnCreate is `true`. Valid value are either `true` or `false` | boolean |
 
+**isOpenShift** Recent versions of OpenShift (tested on 4.13.3) require the specified user to be in an uid range which is dynamically assigned by the namespace. The solution is to unset the runAsUser variable via ``deployment.securityContext.runAsUser=null`` and let OpenShift assign it at install.
+
 **ReloadOnCreate** reloadOnCreate controls how Reloader handles secrets being added to the cache for the first time. If reloadOnCreate is set to true:
 
 - Configmaps/secrets being added to the cache will cause Reloader to perform a rolling update of the associated workload.


### PR DESCRIPTION
### Description:

Adds documentation for usage on OpenShift 4.13 which fixes security constraint errors.
Without the unset of the runAsUser Variable the pods cannot start due to security restrictions.

### Related Issue(s)

- https://github.com/stakater/Reloader/issues/491

### Changes Made

- Wrote a block in the README.md

### How to Test

1. try to install the latest version without the runAsUser unset on OpenShift >=4.13
``helm install reloader stakater/reloader --set reloader.isOpenshift=true``
2. see securityConstraint errors as described in the related issue.
3. remove reloader
``helm uninstall reloader``
4. install the latest version with the unset, for example via
``helm install reloader stakater/reloader --set reloader.isOpenshift=true --set reloader.deployment.securityContext.runAsUser=null``
5. see, that the pods are starting and the logs are clean