### PR TITLE
Remove persist-credentials flag in checkout step of the actions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       # Setting up helm binary


### PR DESCRIPTION
- Setting this to false causes the GitHub action to use the PAT of the person who pushed the changes to the repo. 
- Removing this will set the value to true by default thereby persisting inbuilt github_token across all the steps including the commit step which is currently failing.
- GitHub removes this in post-run step.