### PR TITLE
Updated checkout step of push action to use our token instead of the default github token

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.STAKATER_GITHUB_TOKEN }}        
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       # Setting up helm binary


### PR DESCRIPTION
- Commit step of Push is failing with the default token.
- Using Stakater's token with permissions in the actions.