### PR TITLE
fix(helm-chart): add missing rbac for cronjob-triggering

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -86,6 +86,19 @@ rules:
       - get
       - update
       - patch
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
 {{- if .Values.reloader.enableHA }}
   - apiGroups:
       - "coordination.k8s.io"

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -77,6 +77,19 @@ rules:
       - get
       - update
       - patch
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
 {{- if .Values.reloader.enableHA }}
   - apiGroups:
       - "coordination.k8s.io"


### PR DESCRIPTION
Add missing rbac-rules for new cronjob-handling (see https://github.com/stakater/Reloader/commit/5033d67e749b6a8a13556d667e30f36968489b24), fixes error:
> Failed to list cronjobs cronjobs.batch is forbidden: User "system:serviceaccount:<<redacted>>:stakater-reloader" cannot list resource "cronjobs" in API group "batch" in the namespace "<<redacted>>"