### PR TITLE
Add permissions on CronJob objects

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -77,6 +77,15 @@ rules:
       - update
       - patch
   - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
       - "extensions"
     resources:
       - deployments

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -68,6 +68,15 @@ rules:
       - update
       - patch
   - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
       - "extensions"
     resources:
       - deployments


### PR DESCRIPTION
CronJob support was added in https://github.com/stakater/Reloader/pull/486, but it looks like permissions were missed for the helm chart.

I'm not actually using the CronJob functionality, but I was seeing this message a lot in the output of Reloader.

```
Failed to list cronjobs cronjobs.batch is forbidden: User "system:serviceaccount:stakater-reloader:reloader-reloader" cannot list resource "cronjobs" in API group "batch" in the namespace "namespace"
```