### PR TITLE
feat(helm) add egress-rule to netpol

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -31,7 +31,7 @@ spec:
   egress:
     - ports:
         - port: 443
-      {{- with .Values.reloader.netpol.from}}
+      {{- with .Values.reloader.netpol.to}}
       to:
         {{- toYaml .| nindent 8 }}
       {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -20,11 +20,19 @@ spec:
 {{- end }}
   policyTypes:
   - Ingress
+  - Egress
   ingress:
     - ports:
         - port: http
       {{- with .Values.reloader.netpol.from}}
       from:
+        {{- toYaml .| nindent 8 }}
+      {{- end }}
+  egress:
+    - ports:
+        - port: 443
+      {{- with .Values.reloader.netpol.from}}
+      to:
         {{- toYaml .| nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -276,5 +276,6 @@ reloader:
     # - podSelector:
     #     matchLabels:
     #       app.kubernetes.io/name: prometheus
+    to: []
     
   webhookUrl: ""


### PR DESCRIPTION
Readloder needs access to kubernetes-api, so this adds the corresponding egress-rule to the NetworkPolicy of the helm-chart. 