### PR TITLE
removing extra whitespace in builder image name

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -181,7 +181,7 @@ jobs:
         push: true
         build-args: |
           BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-          BUILDER_IMAGE=gcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
+          BUILDER_IMAGE=ghcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
         cache-to: type=inline
         platforms: linux/amd64,linux/arm64
         tags: |

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -136,7 +136,7 @@ jobs:
           BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
           BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
         cache-to: type=inline
-        platforms: linux/amd64,linux/arm,linux/arm64
+        platforms: linux/amd64,linux/arm64
         tags: |
           ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_UBI_TAG }}
         labels: |
@@ -181,9 +181,9 @@ jobs:
         push: true
         build-args: |
           BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-          BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
+          BUILDER_IMAGE=gcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
         cache-to: type=inline
-        platforms: linux/amd64,linux/arm,linux/arm64
+        platforms: linux/amd64,linux/arm64
         tags: |
           ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_UBI_TAG }}
         labels: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -123,7 +123,7 @@ jobs:
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
             BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           cache-to: type=inline
-          platforms: linux/amd64,linux/arm,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}:ubi-${{ steps.generate_tag.outputs.new_tag }}
           labels: |
@@ -168,9 +168,9 @@ jobs:
           push: true
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-            BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
+            BUILDER_IMAGE=gcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           cache-to: type=inline
-          platforms: linux/amd64,linux/arm,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}:ubi-${{ steps.generate_tag.outputs.new_tag }}
           labels: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -168,7 +168,7 @@ jobs:
           push: true
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-            BUILDER_IMAGE=gcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
+            BUILDER_IMAGE=ghcr.io/${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           tags: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -121,7 +121,7 @@ jobs:
           push: true
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-            BUILDER_IMAGE= ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
+            BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
@@ -168,7 +168,7 @@ jobs:
           push: true
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-            BUILDER_IMAGE= ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
+            BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
           cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,9 @@
 ARG BUILDER_IMAGE
 ARG BASE_IMAGE
 
-FROM ${BUILDER_IMAGE} as SRC
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as SRC
 
-FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi-minimal}
+FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi-minimal:latest}
 
 WORKDIR /
 COPY --from=SRC /manager .


### PR DESCRIPTION
This extra whitespace was breaking the push pipeline. I think there is also an issue with the pull_request pipeline. I am unsure how to test the pipeline changes, if there is someone who could help, please?