### PR TITLE
fix: Add chart parameters for setting revisionHistoryLimit

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
 {{- else }}
   replicas: {{ .Values.reloader.deployment.replicas }}
 {{- end}}
-  revisionHistoryLimit: 2
+  revisionHistoryLimit: {{ .Values.reloader.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "reloader-fullname" . }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -35,6 +35,9 @@ reloader:
   deployment:
     # If you wish to run multiple replicas set reloader.enableHA = true
     replicas: 1
+
+    revisionHistoryLimit: 2
+
     nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
 


### PR DESCRIPTION
Default value is set to the previously-hardcoded value of 2 so remains backwards compatible.