### PR TITLE
Enabled the option to set user assigned affinity value

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -57,8 +57,9 @@ spec:
       affinity:
       {{- if .Values.reloader.deployment.affinity }}
 {{ toYaml .Values.reloader.deployment.affinity | indent 8 }}
-      {{- end}}
+      {{- else }}
 {{ include "reloader-podAntiAffinity" . | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- if .Values.reloader.deployment.tolerations }}
       tolerations:


### PR DESCRIPTION
1. This PR is with reference to https://github.com/stakater/Reloader/issues/593.
2. Tested out 3 scenarios : -> Results looks good  as mentioned below 
a. Enabled HA = true , replicas =3 and affinity set , then user supplied affinity value is effective.
b. Enabled HA = true , replicas =3 and affinity is disabled , then default affinity (reloader-podAntiAffinity) value is effective.
c. Disabled HA and replica =1 , then no affinity value , then default (reloader-podAntiAffinity) is not effective.



Thanks,
Sanghamitra