### PR TITLE
Add namespace field to avoid helm template failure

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "reloader-fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.reloader.podDisruptionBudget.minAvailable }}
   selector:

--- a/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
@@ -14,6 +14,8 @@ metadata:
   name: {{ template "reloader-fullname" . }}
 {{- if .Values.reloader.podMonitor.namespace }}
   namespace: {{ tpl .Values.reloader.podMonitor.namespace . }}
+{{- else }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- end }}
 spec:
   podMetricsEndpoints:

--- a/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
@@ -14,6 +14,8 @@ metadata:
   name: {{ template "reloader-fullname" . }}
 {{- if .Values.reloader.serviceMonitor.namespace }}
   namespace: {{ tpl .Values.reloader.serviceMonitor.namespace . }}
+{{- else }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
helm template -n xxx-ns can not add the namespace field, this PR is to supplement the remainder resources with namespace field.