### PR TITLE
issue/587 - [BUG] helm labels and annotations are added to k8s manifests built with kustomize

### DIFF
--- a/deployments/kubernetes/manifests/clusterrole.yaml
+++ b/deployments/kubernetes/manifests/clusterrole.yaml
@@ -4,15 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 
 kind: ClusterRole
 metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "reloader"
-  labels:
-    app: reloader-reloader
-    chart: "reloader-1.0.65"
-    release: "reloader"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role
 rules:
   - apiGroups:

--- a/deployments/kubernetes/manifests/clusterrolebinding.yaml
+++ b/deployments/kubernetes/manifests/clusterrolebinding.yaml
@@ -4,15 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "reloader"
-  labels:
-    app: reloader-reloader
-    chart: "reloader-1.0.65"
-    release: "reloader"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deployments/kubernetes/manifests/deployment.yaml
+++ b/deployments/kubernetes/manifests/deployment.yaml
@@ -3,18 +3,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "reloader"
-  labels:
-    app: reloader-reloader
-    chart: "reloader-1.0.65"
-    release: "reloader"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-    group: com.stakater.platform
-    provider: stakater
-    version: v1.0.65
   name: reloader-reloader
   namespace: default
 spec:
@@ -25,16 +13,6 @@ spec:
       app: reloader-reloader
       release: "reloader"
   template:
-    metadata:
-      labels:
-        app: reloader-reloader
-        chart: "reloader-1.0.65"
-        release: "reloader"
-        heritage: "Helm"
-        app.kubernetes.io/managed-by: "Helm"
-        group: com.stakater.platform
-        provider: stakater
-        version: v1.0.65
     spec:
       containers:
       - image: "ghcr.io/stakater/reloader:v1.0.65"

--- a/deployments/kubernetes/manifests/serviceaccount.yaml
+++ b/deployments/kubernetes/manifests/serviceaccount.yaml
@@ -3,14 +3,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "reloader"
-  labels:
-    app: reloader-reloader
-    chart: "reloader-1.0.65"
-    release: "reloader"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
   name: reloader-reloader
   namespace: default


### PR DESCRIPTION
## Problem Statement

See #587. [BUG] helm labels and annotations are added to k8s manifests built with Kustomize.

When rendering/deploying k8s resources for Reloader with kustomize, helm labels and annotations are being added to the k8s manifests. This can be misleading. 

## Related Issue

Fixes #587  

## Proposed Changes

Removed Helm labels and annotations from yaml files within the `deployments/kubernetes/manifests` folder.

```bash
kustomize build deployments/kubernetes
```

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reloader-reloader
  namespace: default
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: reloader-reloader-role
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  - configmaps
  verbs:
  - list
  - get
  - watch
- apiGroups:
  - apps
  resources:
  - deployments
  - daemonsets
  - statefulsets
  verbs:
  - list
  - get
  - update
  - patch
- apiGroups:
  - extensions
  resources:
  - deployments
  - daemonsets
  verbs:
  - list
  - get
  - update
  - patch
- apiGroups:
  - batch
  resources:
  - cronjobs
  verbs:
  - list
  - get
- apiGroups:
  - batch
  resources:
  - jobs
  verbs:
  - create
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - patch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: reloader-reloader-role-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: reloader-reloader-role
subjects:
- kind: ServiceAccount
  name: reloader-reloader
  namespace: default
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reloader-reloader
  namespace: default
spec:
  replicas: 1
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: reloader-reloader
      release: reloader
  template:
    spec:
      containers:
      - image: ghcr.io/stakater/reloader:v1.0.65
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 5
          httpGet:
            path: /live
            port: http
          initialDelaySeconds: 10
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 5
        name: reloader-reloader
        ports:
        - containerPort: 9090
          name: http
        readinessProbe:
          failureThreshold: 5
          httpGet:
            path: /metrics
            port: http
          initialDelaySeconds: 10
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 5
        securityContext: {}
      securityContext:
        runAsNonRoot: true
        runAsUser: 65534
      serviceAccountName: reloader-reloader

```

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff` 