### PR TITLE
Workflow updates for paths

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,6 +4,16 @@ on:
   pull_request_target:
     branches:
       - master
+    paths:
+      - '**'
+      - '!.markdownlint.yaml'
+      - '!.vale.ini'
+      - '!Dockerfile-docs'
+      - '!docs-nginx.conf'
+      - '!docs/**'
+      - '!README.md'
+      - '!theme_common'
+      - '!theme_override'
 
 env:
   DOCKER_FILE_PATH: Dockerfile

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,7 +11,6 @@ on:
       - '!Dockerfile-docs'
       - '!docs-nginx.conf'
       - '!docs/**'
-      - '!README.md'
       - '!theme_common'
       - '!theme_override'
 
@@ -23,6 +22,12 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  qa:
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.73
+    with:
+      MD_CONFIG: .github/md_config.json
+      DOC_SRC: README.md
+      MD_LINT_CONFIG: .markdownlint.yaml
   build:
     runs-on: ubuntu-latest
     name: Build

--- a/.github/workflows/pull_request_docs.yaml
+++ b/.github/workflows/pull_request_docs.yaml
@@ -10,7 +10,6 @@ on:
       - 'Dockerfile-docs'
       - 'docs-nginx.conf'
       - 'docs/**'
-      - 'README.md'
       - 'theme_common'
       - 'theme_override'
 
@@ -19,7 +18,7 @@ jobs:
     uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.73
     with:
       MD_CONFIG: .github/md_config.json
-      DOC_SRC: README.md docs
+      DOC_SRC: docs
       MD_LINT_CONFIG: .markdownlint.yaml
   build:
     uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.73

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,6 @@ on:
       - '!Dockerfile-docs'
       - '!docs-nginx.conf'
       - '!docs/**'
-      - '!README.md'
       - '!theme_common'
       - '!theme_override'
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**'
+      - '!.markdownlint.yaml'
+      - '!.vale.ini'
+      - '!Dockerfile-docs'
+      - '!docs-nginx.conf'
+      - '!docs/**'
+      - '!README.md'
+      - '!theme_common'
+      - '!theme_override'
 
 env:
   DOCKER_FILE_PATH: Dockerfile
@@ -23,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.STAKATER_GITHUB_TOKEN }}        
+          token: ${{ secrets.STAKATER_GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       # Setting up helm binary
@@ -31,14 +41,14 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: v3.11.3
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           check-latest: true
           cache: true
-      
+
       - name: Install Dependencies
         run: |
           make install
@@ -233,7 +243,6 @@ jobs:
           commit_username: stakater-user
           commit_email: stakater@gmail.com
 
-      
       # Commit back changes
       - name: Log info about `.git` directory permissions
         run: |


### PR DESCRIPTION
* Only have the Golang workflow run when non-doc files are changed - this workflow updates the Helm chart, which only needs to be updated when Golang files are updated, not when doc files are updated
* When doc files are changed, only run the doc workflow
* The release workflow should always run
* README should be treated separately, it is not part of the doc sites