### PR TITLE
Change git submodule url from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "theme_common"]
 	path = theme_common
-	url = git@github.com:stakater/stakater-docs-mkdocs-theme.git
+	url = https://github.com/stakater/stakater-docs-mkdocs-theme.git 


### PR DESCRIPTION
Issue described - https://github.com/stakater/Reloader/issues/658

Change theme_common git submodule url from ssh to https due to ArgoCD error