### PR TITLE
bump go from 1.21.6 -> 1.21.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE
 ARG BASE_IMAGE
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.21.6} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.21.9} as builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Resolves several CVEs.

Prior to this change:
```
ghcr.io/stakater/reloader:v1.0.101 (debian 12.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


manager (gobinary)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.6            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of          │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                              │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288                  │
│         ├────────────────┼──────────┤        │                   ├────────────────┼─────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45289 │ MEDIUM   │        │                   │ 1.21.8, 1.22.1 │ golang: net/http/cookiejar: incorrect forwarding of         │
│         │                │          │        │                   │                │ sensitive headers and cookies on HTTP redirect...           │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45289                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45290 │          │        │                   │                │ golang: net/http: memory exhaustion in                      │
│         │                │          │        │                   │                │ Request.ParseMultipartForm                                  │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45290                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24783 │          │        │                   │                │ golang: crypto/x509: Verify panics on certificates with an  │
│         │                │          │        │                   │                │ unknown public key algorithm...                             │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-24783                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24784 │          │        │                   │                │ golang: net/mail: comments in display names are incorrectly │
│         │                │          │        │                   │                │ handled                                                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-24784                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24785 │          │        │                   │                │ golang: html/template: errors returned from MarshalJSON     │
│         │                │          │        │                   │                │ methods may break template escaping                         │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-24785                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```

Following this change, `trivy` reports zero CVE :tada: 