### PR TITLE
fix: replace + with _ in Chart.Version

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
+++ b/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "reloader-labels.chart" -}}
 app: {{ template "reloader-fullname" . }}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}


### PR DESCRIPTION
When using Flux with the OCI chart, the chart version has a git hash
suffix (ex: 1.0.107+20eb5010550b), which is invalid as a metadata label.