### PR TITLE
feat: add new opt-in metric of reloads by namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ helm uninstall {{RELEASE_NAME}} -n {{NAMESPACE}}
 | `reloader.readOnlyRootFileSystem` | Enforce readOnlyRootFilesystem                                                                                                                      | boolean     | `false`   |
 | `reloader.legacy.rbac`            |                                                                                                                                                     | boolean     | `false`   |
 | `reloader.matchLabels`            | Pod labels to match                                                                                                                                 | map         | `{}`      |
+| `reloader.enableMetricsByNamespace`            | Expose an additional Prometheus counter of reloads by namespace (this metric may have high cardinality in clusters with many namespaces) | boolean         | `false`      |
 
 #### Deployment Reloader Parameters
 

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       - image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
         imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
         name: {{ template "reloader-fullname" . }}
-      {{- if or (.Values.reloader.deployment.env.open) (.Values.reloader.deployment.env.secret) (.Values.reloader.deployment.env.field) (.Values.reloader.deployment.env.existing) (eq .Values.reloader.watchGlobally false) (.Values.reloader.enableHA)}}
+      {{- if or (.Values.reloader.deployment.env.open) (.Values.reloader.deployment.env.secret) (.Values.reloader.deployment.env.field) (.Values.reloader.deployment.env.existing) (eq .Values.reloader.watchGlobally false) (.Values.reloader.enableHA) (.Values.reloader.enableMetricsByNamespace)}}
         env:
       {{- range $name, $value := .Values.reloader.deployment.env.open }}
       {{- if not (empty $value) }}
@@ -128,6 +128,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      {{- end }}
+      {{- if .Values.reloader.enableMetricsByNamespace }}
+        - name: METRICS_COUNT_BY_NAMESPACE
+          value: enabled
       {{- end }}
       {{- end }}
 

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -32,6 +32,8 @@ reloader:
   legacy:
     rbac: false
   matchLabels: {}
+  # Set to true to expose a prometheus counter of reloads by namespace (this metric may have high cardinality in clusters with many namespaces)
+  enableMetricsByNamespace: false
   deployment:
     # If you wish to run multiple replicas set reloader.enableHA = true
     replicas: 1

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -23,6 +23,8 @@ reloader:
   legacy:
     rbac: false
   matchLabels: {}
+  # Set to true to expose a prometheus counter of reloads by namespace (this metric may have high cardinality in clusters with many namespaces)
+  enableMetricsByNamespace: false
   deployment:
     replicas: 1
     nodeSelector:

--- a/docs/Verify-Reloader-Working.md
+++ b/docs/Verify-Reloader-Working.md
@@ -61,7 +61,7 @@ reloader_reload_executed_total{success="false"} 15
 reloader_reload_executed_total{success="true"} 12
 ```
 
-### Opt-in Granular Metrics
+### Reloads by Namespace
 
 Reloader can also export a metric to show the number of reloads by namespace. This feature is disabled by default, as it can lead to high cardinality in clusters with many namespaces.
 
@@ -72,4 +72,4 @@ reloader_reload_executed_total{success="false", namespace="some-namespace"} 2
 reloader_reload_executed_total{success="true", namespace="some-namespace"} 1
 ```
 
-To opt-in, set the environment variable `METRICS_COUNT_BY_NAMESPACE` to `enabled` or set the Helm value `reloader.enableMetricsByNamespace` to `true`.
+To opt in, set the environment variable `METRICS_COUNT_BY_NAMESPACE` to `enabled` or set the Helm value `reloader.enableMetricsByNamespace` to `true`.

--- a/docs/Verify-Reloader-Working.md
+++ b/docs/Verify-Reloader-Working.md
@@ -60,3 +60,16 @@ When Reloader is unable to reload, `reloader_reload_executed_total{success="fals
 reloader_reload_executed_total{success="false"} 15
 reloader_reload_executed_total{success="true"} 12
 ```
+
+### Opt-in Granular Metrics
+
+Reloader can also export a metric to show the number of reloads by namespace. This feature is disabled by default, as it can lead to high cardinality in clusters with many namespaces.
+
+The metric will have both `success` and `namespace` as attributes:
+
+```text
+reloader_reload_executed_total{success="false", namespace="some-namespace"} 2
+reloader_reload_executed_total{success="true", namespace="some-namespace"} 1
+```
+
+To opt-in, set the environment variable `METRICS_COUNT_BY_NAMESPACE` to `enabled` or set the Helm value `reloader.enableMetricsByNamespace` to `true`.

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -245,6 +245,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 				message := fmt.Sprintf("Update for '%s' of type '%s' in namespace '%s' failed with error %v", resourceName, upgradeFuncs.ResourceType, config.Namespace, err)
 				logrus.Errorf(message)
 				collectors.Reloaded.With(prometheus.Labels{"success": "false"}).Inc()
+				collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "false", "namespace": config.Namespace}).Inc()
 				if recorder != nil {
 					recorder.Event(i, v1.EventTypeWarning, "ReloadFail", message)
 				}
@@ -254,6 +255,7 @@ func PerformRollingUpgrade(clients kube.Clients, config util.Config, upgradeFunc
 				message += fmt.Sprintf(", Updated '%s' of type '%s' in namespace '%s'", resourceName, upgradeFuncs.ResourceType, config.Namespace)
 				logrus.Infof(message)
 				collectors.Reloaded.With(prometheus.Labels{"success": "true"}).Inc()
+				collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": config.Namespace}).Inc()
 				alert_on_reload, ok := os.LookupEnv("ALERT_ON_RELOAD")
 				if recorder != nil {
 					recorder.Event(i, v1.EventTypeNormal, "Reloaded", message)

--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -1465,7 +1465,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUs
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 1 {
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -1508,7 +1508,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNotMappedUsi
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 1 {
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }

--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -1278,12 +1278,12 @@ func getConfigWithAnnotations(resourceType string, name string, shaData string, 
 	}
 
 	return util.Config{
-		Namespace:            ns,
-		ResourceName:         name,
-		SHAValue:             shaData,
-		Annotation:           annotation,
-		TypedAutoAnnotation:  typedAutoAnnotation,
-		Type:                 resourceType,
+		Namespace:           ns,
+		ResourceName:        name,
+		SHAValue:            shaData,
+		Annotation:          annotation,
+		TypedAutoAnnotation: typedAutoAnnotation,
+		Type:                resourceType,
 	}
 }
 
@@ -1317,6 +1317,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationAndWithoutAutoReloadAllNoTriggersUsingArs(t *testing.T) {
@@ -1340,7 +1344,11 @@ func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationAndWitho
 	}
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
-		t.Errorf("Counter was increased")
+		t.Errorf("Counter was increased unexpectedly")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
+		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
 
@@ -1369,6 +1377,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationButWithA
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingArs(t *testing.T) {
@@ -1392,6 +1404,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingArs(t *te
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1418,6 +1434,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationUsingArs(t *
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUsingArs(t *testing.T) {
@@ -1443,6 +1463,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUs
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
 		t.Errorf("Counter was increased unexpectedly")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 1 {
+		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
 
@@ -1483,6 +1507,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNotMappedUsi
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
 		t.Errorf("Counter was increased unexpectedly")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 1 {
+		t.Errorf("Counter by namespace was increased unexpectedly")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingArs(t *testing.T) {
@@ -1507,6 +1535,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingArs(t *test
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1533,6 +1565,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectVolumeInInitContainerU
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingArs(t *testing.T) {
@@ -1557,6 +1593,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingArs(t *testing.T) 
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1583,6 +1623,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarInInitContainerUsingArs
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingArs(t *testing.T) {
@@ -1607,6 +1651,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingArs(t *testing
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1633,6 +1681,10 @@ func TestRollingUpgradeForDeploymentWithSecretUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingArs(t *testing.T) {
@@ -1657,6 +1709,10 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingArs(t *testi
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1683,6 +1739,10 @@ func TestRollingUpgradeForDeploymentWithSecretinInitContainerUsingArs(t *testing
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUsingArs(t *testing.T) {
@@ -1707,6 +1767,10 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUs
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1733,6 +1797,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingArs(t *testing.T) {
@@ -1757,6 +1825,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingArs(t *testing.T)
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1783,6 +1855,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarInInitContainerUsingArs(t 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingArs(t *testing.T) {
@@ -1807,6 +1883,10 @@ func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingArs(t *testing.
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1833,6 +1913,10 @@ func TestRollingUpgradeForDeploymentWithConfigMapAutoAnnotationUsingArs(t *testi
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithConfigmapUsingArs(t *testing.T) {
@@ -1857,6 +1941,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapUsingArs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1883,6 +1971,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapInProjectedVolumeUsingArs(t *tes
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingArs(t *testing.T) {
@@ -1907,6 +1999,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingArs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1933,6 +2029,10 @@ func TestRollingUpgradeForDaemonSetWithSecretUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingArs(t *testing.T) {
@@ -1957,6 +2057,10 @@ func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingArs(t *testin
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -1983,6 +2087,10 @@ func TestRollingUpgradeForStatefulSetWithConfigmapUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingArs(t *testing.T) {
@@ -2007,6 +2115,10 @@ func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingArs(t *t
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2033,6 +2145,10 @@ func TestRollingUpgradeForStatefulSetWithSecretUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingArs(t *testing.T) {
@@ -2057,6 +2173,10 @@ func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingArs(t *test
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2110,6 +2230,10 @@ func TestRollingUpgradeForDeploymentWithPodAnnotationsUsingArs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestFailedRollingUpgradeUsingArs(t *testing.T) {
@@ -2127,6 +2251,10 @@ func TestFailedRollingUpgradeUsingArs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelFailed)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "false", "namespace": arsNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2153,6 +2281,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingErs(t *testing.T) {
@@ -2176,6 +2308,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingErs(t *te
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2202,6 +2338,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationUsingErs(t *
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUsingErs(t *testing.T) {
@@ -2227,6 +2367,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUs
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
 		t.Errorf("Counter was increased unexpectedly")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
+		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
 
@@ -2267,6 +2411,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNotMappedUsi
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) > 0 {
 		t.Errorf("Counter was increased unexpectedly")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
+		t.Errorf("Counter by namespace was increased unexpectedly")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingErs(t *testing.T) {
@@ -2291,6 +2439,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingErs(t *test
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2317,6 +2469,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectVolumeInInitContainerU
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingErs(t *testing.T) {
@@ -2341,6 +2497,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingErs(t *testing.T) 
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2367,6 +2527,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarInInitContainerUsingErs
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingErs(t *testing.T) {
@@ -2391,6 +2555,10 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingErs(t *testing
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2417,6 +2585,10 @@ func TestRollingUpgradeForDeploymentWithSecretUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingErs(t *testing.T) {
@@ -2441,6 +2613,10 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingErs(t *testi
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2467,6 +2643,10 @@ func TestRollingUpgradeForDeploymentWithSecretinInitContainerUsingErs(t *testing
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUsingErs(t *testing.T) {
@@ -2491,6 +2671,10 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUs
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2517,6 +2701,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingErs(t *testing.T) {
@@ -2541,6 +2729,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingErs(t *testing.T)
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2567,6 +2759,10 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarInInitContainerUsingErs(t 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingErs(t *testing.T) {
@@ -2591,6 +2787,10 @@ func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingErs(t *testing.
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2617,6 +2817,10 @@ func TestRollingUpgradeForDeploymentWithConfigMapAutoAnnotationUsingErs(t *testi
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithConfigmapUsingErs(t *testing.T) {
@@ -2641,6 +2845,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapUsingErs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2667,6 +2875,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapInProjectedVolumeUsingErs(t *tes
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingErs(t *testing.T) {
@@ -2691,6 +2903,10 @@ func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingErs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2717,6 +2933,10 @@ func TestRollingUpgradeForDaemonSetWithSecretUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingErs(t *testing.T) {
@@ -2741,6 +2961,10 @@ func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingErs(t *testin
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2767,6 +2991,10 @@ func TestRollingUpgradeForStatefulSetWithConfigmapUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingErs(t *testing.T) {
@@ -2791,6 +3019,10 @@ func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingErs(t *t
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2817,6 +3049,10 @@ func TestRollingUpgradeForStatefulSetWithSecretUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingErs(t *testing.T) {
@@ -2841,6 +3077,10 @@ func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingErs(t *test
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }
 
@@ -2895,6 +3135,10 @@ func TestRollingUpgradeForDeploymentWithPodAnnotationsUsingErs(t *testing.T) {
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelSucceeded)) != 1 {
 		t.Errorf("Counter was not increased")
 	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
+	}
 }
 
 func TestFailedRollingUpgradeUsingErs(t *testing.T) {
@@ -2912,5 +3156,9 @@ func TestFailedRollingUpgradeUsingErs(t *testing.T) {
 
 	if promtestutil.ToFloat64(collectors.Reloaded.With(labelFailed)) != 1 {
 		t.Errorf("Counter was not increased")
+	}
+
+	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "false", "namespace": ersNamespace})) != 1 {
+		t.Errorf("Counter by namespace was not increased")
 	}
 }

--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -1318,7 +1318,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1347,7 +1347,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationAndWitho
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -1378,7 +1378,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapWithoutReloadAnnotationButWithA
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1406,7 +1406,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingArs(t *te
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1435,7 +1435,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationUsingArs(t *
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1465,7 +1465,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUs
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -1508,7 +1508,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNotMappedUsi
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -1537,7 +1537,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingArs(t *test
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1566,7 +1566,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectVolumeInInitContainerU
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1595,7 +1595,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingArs(t *testing.T) 
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1624,7 +1624,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarInInitContainerUsingArs
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1653,7 +1653,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingArs(t *testing
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1682,7 +1682,7 @@ func TestRollingUpgradeForDeploymentWithSecretUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1711,7 +1711,7 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingArs(t *testi
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1740,7 +1740,7 @@ func TestRollingUpgradeForDeploymentWithSecretinInitContainerUsingArs(t *testing
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1769,7 +1769,7 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUs
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1798,7 +1798,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1827,7 +1827,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingArs(t *testing.T)
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1856,7 +1856,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarInInitContainerUsingArs(t 
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1885,7 +1885,7 @@ func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingArs(t *testing.
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1914,7 +1914,7 @@ func TestRollingUpgradeForDeploymentWithConfigMapAutoAnnotationUsingArs(t *testi
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1943,7 +1943,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -1972,7 +1972,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapInProjectedVolumeUsingArs(t *tes
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2001,7 +2001,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2030,7 +2030,7 @@ func TestRollingUpgradeForDaemonSetWithSecretUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2059,7 +2059,7 @@ func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingArs(t *testin
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2088,7 +2088,7 @@ func TestRollingUpgradeForStatefulSetWithConfigmapUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2117,7 +2117,7 @@ func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingArs(t *t
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2146,7 +2146,7 @@ func TestRollingUpgradeForStatefulSetWithSecretUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2175,7 +2175,7 @@ func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingArs(t *test
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2231,7 +2231,7 @@ func TestRollingUpgradeForDeploymentWithPodAnnotationsUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2253,7 +2253,7 @@ func TestFailedRollingUpgradeUsingArs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "false", "namespace": arsNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "false", "namespace": arsNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2282,7 +2282,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2310,7 +2310,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectedVolumeUsingErs(t *te
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2339,7 +2339,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationUsingErs(t *
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2369,7 +2369,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNoTriggersUs
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -2412,7 +2412,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapViaSearchAnnotationNotMappedUsi
 		t.Errorf("Counter was increased unexpectedly")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) > 0 {
 		t.Errorf("Counter by namespace was increased unexpectedly")
 	}
 }
@@ -2441,7 +2441,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInInitContainerUsingErs(t *test
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2470,7 +2470,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapInProjectVolumeInInitContainerU
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2499,7 +2499,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarUsingErs(t *testing.T) 
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2528,7 +2528,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarInInitContainerUsingErs
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2557,7 +2557,7 @@ func TestRollingUpgradeForDeploymentWithConfigmapAsEnvVarFromUsingErs(t *testing
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2586,7 +2586,7 @@ func TestRollingUpgradeForDeploymentWithSecretUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2615,7 +2615,7 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeUsingErs(t *testi
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2644,7 +2644,7 @@ func TestRollingUpgradeForDeploymentWithSecretinInitContainerUsingErs(t *testing
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2673,7 +2673,7 @@ func TestRollingUpgradeForDeploymentWithSecretInProjectedVolumeinInitContainerUs
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2702,7 +2702,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2731,7 +2731,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarFromUsingErs(t *testing.T)
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2760,7 +2760,7 @@ func TestRollingUpgradeForDeploymentWithSecretAsEnvVarInInitContainerUsingErs(t 
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2789,7 +2789,7 @@ func TestRollingUpgradeForDeploymentWithSecretAutoAnnotationUsingErs(t *testing.
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2818,7 +2818,7 @@ func TestRollingUpgradeForDeploymentWithConfigMapAutoAnnotationUsingErs(t *testi
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2847,7 +2847,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2876,7 +2876,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapInProjectedVolumeUsingErs(t *tes
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2905,7 +2905,7 @@ func TestRollingUpgradeForDaemonSetWithConfigmapAsEnvVarUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2934,7 +2934,7 @@ func TestRollingUpgradeForDaemonSetWithSecretUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2963,7 +2963,7 @@ func TestRollingUpgradeForDaemonSetWithSecretInProjectedVolumeUsingErs(t *testin
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -2992,7 +2992,7 @@ func TestRollingUpgradeForStatefulSetWithConfigmapUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -3021,7 +3021,7 @@ func TestRollingUpgradeForStatefulSetWithConfigmapInProjectedVolumeUsingErs(t *t
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -3050,7 +3050,7 @@ func TestRollingUpgradeForStatefulSetWithSecretUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -3079,7 +3079,7 @@ func TestRollingUpgradeForStatefulSetWithSecretInProjectedVolumeUsingErs(t *test
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -3136,7 +3136,7 @@ func TestRollingUpgradeForDeploymentWithPodAnnotationsUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "true", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }
@@ -3158,7 +3158,7 @@ func TestFailedRollingUpgradeUsingErs(t *testing.T) {
 		t.Errorf("Counter was not increased")
 	}
 
-	if promtestutil.ToFloat64(collectors.Reloaded.With(prometheus.Labels{"success": "false", "namespace": ersNamespace})) != 1 {
+	if promtestutil.ToFloat64(collectors.ReloadedByNamespace.With(prometheus.Labels{"success": "false", "namespace": ersNamespace})) != 1 {
 		t.Errorf("Counter by namespace was not increased")
 	}
 }

--- a/internal/pkg/metrics/prometheus.go
+++ b/internal/pkg/metrics/prometheus.go
@@ -1,13 +1,16 @@
 package metrics
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"net/http"
 )
 
 type Collectors struct {
-	Reloaded *prometheus.CounterVec
+	Reloaded            *prometheus.CounterVec
+	ReloadedByNamespace *prometheus.CounterVec
 }
 
 func NewCollectors() Collectors {
@@ -17,21 +20,40 @@ func NewCollectors() Collectors {
 			Name:      "reload_executed_total",
 			Help:      "Counter of reloads executed by Reloader.",
 		},
-		[]string{"success"},
+		[]string{
+			"success",
+		},
 	)
 
 	//set 0 as default value
 	reloaded.With(prometheus.Labels{"success": "true"}).Add(0)
 	reloaded.With(prometheus.Labels{"success": "false"}).Add(0)
 
+	reloaded_by_namespace := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "reloader",
+			Name:      "reload_executed_total_by_namespace",
+			Help:      "Counter of reloads executed by Reloader by namespace.",
+		},
+		[]string{
+			"success",
+			"namespace",
+		},
+	)
 	return Collectors{
-		Reloaded: reloaded,
+		Reloaded:            reloaded,
+		ReloadedByNamespace: reloaded_by_namespace,
 	}
 }
 
 func SetupPrometheusEndpoint() Collectors {
 	collectors := NewCollectors()
 	prometheus.MustRegister(collectors.Reloaded)
+
+	if os.Getenv("METRICS_COUNT_BY_NAMESPACE") == "enabled" {
+		prometheus.MustRegister(collectors.ReloadedByNamespace)
+	}
+
 	http.Handle("/metrics", promhttp.Handler())
 
 	return collectors


### PR DESCRIPTION
Reloader currently keeps track of the number of successful and failed reloads. This is useful for general debugging, but in some cases it would also be useful to monitor reloads by namespace.

To implement this, I created a new metric (`reload_executed_total_by_namespace`) with `success` and `namespace` as attributes and disabled it by default, since the cardinality of the metric might get high if it is deployed in a cluster where Reloader manages resources in many namespaces. To keep the code changes minimal, I created a new Prometheus counter and have it increment per-namespace at the same time as the global counter, but I only register the counter if the opt-in flag is set.

I've tested these changes on a cluster I manage, and verified that by default it does not expose the new metric. When the environment variable is set, it looks like this:

![image](https://github.com/stakater/Reloader/assets/10692149/82bae5af-a8ef-4ef3-ac4d-d132ec3e956c)

I've also updated the Helm chart, docs, and README to reflect this new feature.