### PR TITLE
Reduce footprint of UBI images 

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -4,7 +4,8 @@ ARG BASE_IMAGE
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as SRC
 
 FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi:latest} as minimal-ubi
-ARG BUILDPLATFORM
+ARG TARGETARCH
+
 
 RUN dnf update -y && dnf install -y binutils
 # prep target rootfs for scratch container
@@ -16,15 +17,15 @@ RUN mkdir /image && \
 	ln -s usr/lib /image/lib && \
 	mkdir -p /image/{usr/bin,usr/lib64,usr/lib,root,home,proc,etc,sys,var,dev}
 
-COPY ubi-build-files-${BUILDPLATFORM#*/}.txt /tmp
+COPY ubi-build-files-${TARGETARCH}.txt /tmp
 # Copy all the required files from the base UBI image into the image directory
 # As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
-RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${BUILDPLATFORM#*/}.txt && tar xf /tmp/files.tar -C /image/ \
+RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${TARGETARCH}.txt && tar xf /tmp/files.tar -C /image/ \
   && strip --strip-unneeded /image/usr/lib64/*[0-9].so
 
 # Generate a rpm database which contains all the packages that you said were needed in ubi-build-files-*.txt
 RUN rpm --root /image --initdb \
-  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${BUILDPLATFORM#*/}.txt) | grep -v "is not owned by any package" | sort -u) \
+  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${TARGETARCH}.txt) | grep -v "is not owned by any package" | sort -u) \
   && echo dnf install -y 'dnf-command(download)' \
   && dnf download --destdir / ${PACKAGES} \
   && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -15,15 +15,15 @@ RUN mkdir /image && \
 	ln -s usr/lib /image/lib && \
 	mkdir -p /image/{usr/bin,usr/lib64,usr/lib,root,home,proc,etc,sys,var,dev}
 
-COPY ubi-build-files-${${BUILDPLATFORM#*/}}.txt /tmp
+COPY ubi-build-files-${BUILDPLATFORM#*/}.txt /tmp
 # Copy all the required files from the base UBI image into the image directory
 # As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
-RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${${BUILDPLATFORM#*/}}.txt && tar xf /tmp/files.tar -C /image/ \
+RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${BUILDPLATFORM#*/}.txt && tar xf /tmp/files.tar -C /image/ \
   && strip --strip-unneeded /image/usr/lib64/*[0-9].so
 
 # Generate a rpm database which contains all the packages that you said were needed in ubi-build-files-*.txt
 RUN rpm --root /image --initdb \
-  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${${BUILDPLATFORM#*/}}.txt) | grep -v "is not owned by any package" | sort -u) \
+  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${BUILDPLATFORM#*/}.txt) | grep -v "is not owned by any package" | sort -u) \
   && echo dnf install -y 'dnf-command(download)' \
   && dnf download --destdir / ${PACKAGES} \
   && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -4,6 +4,7 @@ ARG BASE_IMAGE
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as SRC
 
 FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi:latest} as minimal-ubi
+ARG BUILDPLATFORM
 
 RUN dnf update -y && dnf install -y binutils
 # prep target rootfs for scratch container

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -3,16 +3,35 @@ ARG BASE_IMAGE
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as SRC
 
-FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi-minimal:latest}
+FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi:latest} as minimal-ubi
 
+RUN dnf update -y && dnf install -y binutils
+# prep target rootfs for scratch container
 WORKDIR /
+RUN mkdir /image && \
+    ln -s usr/bin /image/bin && \
+	ln -s usr/sbin /image/sbin && \
+	ln -s usr/lib64 /image/lib64 && \
+	ln -s usr/lib /image/lib && \
+	mkdir -p /image/{usr/bin,usr/lib64,usr/lib,root,home,proc,etc,sys,var,dev}
+
+COPY ubi-build-files-${${BUILDPLATFORM#*/}}.txt /tmp
+# Copy all the required files from the base UBI image into the image directory
+# As the go binary is not statically compiled this includes everything needed for CGO to work, cacerts, tzdata and RH release files
+RUN tar cf /tmp/files.tar -T /tmp/ubi-build-files-${${BUILDPLATFORM#*/}}.txt && tar xf /tmp/files.tar -C /image/ \
+  && strip --strip-unneeded /image/usr/lib64/*[0-9].so
+
+# Generate a rpm database which contains all the packages that you said were needed in ubi-build-files-*.txt
+RUN rpm --root /image --initdb \
+  && PACKAGES=$(rpm -qf $(cat /tmp/ubi-build-files-${${BUILDPLATFORM#*/}}.txt) | grep -v "is not owned by any package" | sort -u) \
+  && echo dnf install -y 'dnf-command(download)' \
+  && dnf download --destdir / ${PACKAGES} \
+  && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`
+
+FROM scratch
+COPY --from=minimal-ubi /image/ /
 COPY --from=SRC /manager .
-
-# Update image
-RUN microdnf update
-
 USER 65532:65532
-
 # Port for metrics and probes
 EXPOSE 9090
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as SRC
 
-FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi:latest} as minimal-ubi
+FROM ${BASE_IMAGE:-registry.access.redhat.com/ubi8/ubi:latest} as ubi
 ARG TARGETARCH
 
 
@@ -31,7 +31,7 @@ RUN rpm --root /image --initdb \
   && rpm --root /image -ivh --justdb --nodeps `for i in ${PACKAGES}; do echo $i.rpm; done`
 
 FROM scratch
-COPY --from=minimal-ubi /image/ /
+COPY --from=ubi /image/ /
 COPY --from=SRC /manager .
 USER 65532:65532
 # Port for metrics and probes

--- a/ubi-build-files-amd64.txt
+++ b/ubi-build-files-amd64.txt
@@ -1,0 +1,15 @@
+etc/pki
+root/buildinfo
+etc/ssl/certs
+etc/redhat-release
+usr/share/zoneinfo
+usr/lib64/ld-2.28.so
+usr/lib64/ld-linux-x86-64.so.2
+usr/lib64/libc-2.28.so
+usr/lib64/libc.so.6
+usr/lib64/libdl-2.28.so
+usr/lib64/libdl.so.2
+usr/lib64/libpthread-2.28.so
+usr/lib64/libpthread.so.0
+usr/lib64/libm-2.28.so
+usr/lib64/libm.so.6

--- a/ubi-build-files-arm64.txt
+++ b/ubi-build-files-arm64.txt
@@ -1,0 +1,15 @@
+etc/pki
+root/buildinfo
+etc/ssl/certs
+etc/redhat-release
+usr/share/zoneinfo
+usr/lib64/ld-2.28.so
+usr/lib64/ld-linux-aarch64.so.1
+usr/lib64/libc-2.28.so
+usr/lib64/libc.so.6
+usr/lib64/libdl-2.28.so
+usr/lib64/libdl.so.2
+usr/lib64/libpthread-2.28.so
+usr/lib64/libpthread.so.0
+usr/lib64/libm-2.28.so
+usr/lib64/libm.so.6


### PR DESCRIPTION
Uses a multistage build and copies only required packages and rpm database into the final image

#716 