### PR TITLE
chore: fix for POD_NAME and POD_NAMESPACE envs when enableHA is true

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         {{- else }}
           valueFrom:
             resourceFieldRef:
-              resource: limits.memory
+              resource: limits.cpu
         {{- end }}
         - name: GOMEMLIMIT
         {{- if .Values.reloader.deployment.gomemlimitOverride }}
@@ -91,7 +91,7 @@ spec:
         {{- else }}
           valueFrom:
             resourceFieldRef:
-              resource: limits.cpu
+              resource: limits.memory
         {{- end }}
       {{- range $name, $value := .Values.reloader.deployment.env.open }}
       {{- if not (empty $value) }}

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -127,6 +127,7 @@ spec:
             fieldRef:
               fieldPath: {{ $value | quote}}
       {{- end }}
+      {{- end }}
       {{- if eq .Values.reloader.watchGlobally false }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
@@ -146,7 +147,6 @@ spec:
       {{- if .Values.reloader.enableMetricsByNamespace }}
         - name: METRICS_COUNT_BY_NAMESPACE
           value: enabled
-      {{- end }}
       {{- end }}
         ports:
         - name: http

--- a/deployments/kubernetes/chart/reloader/tests/deployment_test.yaml
+++ b/deployments/kubernetes/chart/reloader/tests/deployment_test.yaml
@@ -48,3 +48,16 @@ tests:
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].securityContext
+
+  - it: template still sets POD_NAME and POD_NAMESPACE environment variables when enableHA is true
+    set:
+      reloader:
+        enableHA: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name


### PR DESCRIPTION
fix for POD_NAME and POD_NAMESPACE envs when enableHA is true

Also added a test case to cover it 👍 

Fixes: 

```
Error: POD_NAME not set, cannot run in HA mode without POD_NAME set
```

Likely introduced here https://github.com/stakater/Reloader/pull/699