### PR TITLE
docs: update wording in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Reloader is compatible with Kubernetes >= 1.19
 
 You have a `Deployment` called `foo` and a `ConfigMap` and/or a `Secret` either mounted as a volume or defined as a environment variable. The `ConfigMap` and `Secret` can be named whatever, but for the sake of this example, lets refer to the `ConfigMap` as `foo-configmap` and the secret as `foo-secret`.
 
+Add the annotation to the main metadata of your `Deployment`. By default this would be `reloader.stakater.com/auto`.
+
 ```yaml
 kind: Deployment
 metadata:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Reloader is compatible with Kubernetes >= 1.19
 
 ## How to use Reloader
 
-For a `Deployment` called `foo` have a `ConfigMap` called `foo-configmap` or `Secret` called `foo-secret` or both. Then add your annotation (by default `reloader.stakater.com/auto`) to main metadata of your `Deployment`
+You have a `Deployment` called `foo` and a `ConfigMap` and/or a `Secret` either mounted as a volume or defined as a environment variable. The `ConfigMap` and `Secret` can be named whatever, but for the sake of this example, lets refer to the `ConfigMap` as `foo-configmap` and the secret as `foo-secret`.
 
 ```yaml
 kind: Deployment
 metadata:
+  name: foo
   annotations:
     reloader.stakater.com/auto: "true"
 spec:


### PR DESCRIPTION
Updated the wording in the readme to avoid confusion, because if you read it in a certain way, you might misunderstand and think the configmap and/or secret requires a certain naming convention for reloader to work.

Solves confusion, like in #663 