### PR TITLE
Make sure GOMAXPROCS and GOMEMLIMIT has a divisor set

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+              divisor: '1'
         {{- end }}
         - name: GOMEMLIMIT
         {{- if .Values.reloader.deployment.gomemlimitOverride }}
@@ -92,6 +93,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+              divisor: '1'
         {{- end }}
       {{- range $name, $value := .Values.reloader.deployment.env.open }}
       {{- if not (empty $value) }}

--- a/deployments/kubernetes/manifests/deployment.yaml
+++ b/deployments/kubernetes/manifests/deployment.yaml
@@ -25,10 +25,12 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
+                  divisor: '1'
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+                  divisor: '1'
           ports:
             - name: http
               containerPort: 9090


### PR DESCRIPTION
Currently argocd complains that divisor is different between manifest and live.

I don't fully understand the field, but it looks like it sets how the resource field should be interpreted.

Same fix as https://github.com/traefik/traefik-helm-chart/issues/1065 which seems to be the same problem.
