### PR TITLE
Renovate update for Helm Chart values file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,17 @@
             "https:\/\/github\\.com\/(?<depName>.*)\/releases\/download\/(?<currentValue>.*)\/.*\\.zip"
         ],
         "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Helm Chart values file",
+      "fileMatch": [
+          "values\\.yaml$"
+      ],
+      "matchStrings": [
+          "image:\\s*name: (?<depName>[a-zA-Z0-9\\.\\/]*)\\s*tag: (?<currentValue>[a-zA-Z0-9\\.\\/]*)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Renovate doesn't update the values file because it doesn't follow the conventional format specified on https://docs.renovatebot.com/modules/manager/helm-values/