### PR TITLE
fix: Remove obsolete permissions for apiGroup `extensions` from helm templates

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -77,16 +77,6 @@ rules:
       - update
       - patch
   - apiGroups:
-      - "extensions"
-    resources:
-      - deployments
-      - daemonsets
-    verbs:
-      - list
-      - get
-      - update
-      - patch
-  - apiGroups:
       - "batch"
     resources:
       - cronjobs


### PR DESCRIPTION
`dpeloyments` and `statefulsets` in the apiGroup `extensions` have been deprecated and removed from kubernetes. This changes removes these permissions from the Reloader Role helm template file.