### PR TITLE
Add workflow for helm chart push

### DIFF
--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -1,0 +1,103 @@
+name: Push Helm Chart
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+    paths:
+      - 'deployments/kubernetes/chart/reloader/**'
+
+env:
+  HELM_REGISTRY_URL: "https://stakater.github.io/stakater-charts"
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+
+    permissions:
+      contents: read
+      packages: write # to push artifacts to `ghcr.io`
+
+    name: Build
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PUBLISH_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          submodules: recursive
+
+      # Setting up helm binary
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.11.3
+
+      - name: Add Stakater Helm Repo
+        run: |
+          helm repo add stakater https://stakater.github.io/stakater-charts
+
+      - name: Get version for chart from helm repo
+        id: chart_eval
+        run: |
+          current_chart_version=$(helm search repo stakater/reloader | tail -n 1 | awk '{print $2}')
+          echo "CURRENT_CHART_VERSION=$(echo ${current_chart_version})" >> $GITHUB_OUTPUT
+
+      - name: Get Updated Chart version from Chart.yaml
+        uses: mikefarah/yq@master
+        id: new_chart_version
+        with:
+          cmd: yq e '.version' deployments/kubernetes/chart/reloader/Chart.yaml
+
+      - name: Check Version
+        uses: aleoyakas/check-semver-increased-action@v1
+        id: check-version
+        with:
+          current-version: ${{ steps.new_chart_version.outputs.result }}
+          previous-version: ${{ steps.chart_eval.outputs.CURRENT_CHART_VERSION }}
+
+      - name: Fail if Helm Chart version isnt updated
+        if: steps.check-version.outputs.is-version-increased != 'true'
+        run: |
+          echo "Helm Chart Version wasnt updated"
+          exit 1
+
+      # Publish helm chart
+      - name: Login to ghcr via helm
+        run: |
+          echo ${{secrets.GITHUB_TOKEN}} | helm registry login ghcr.io/stakater --username stakater-user --password-stdin
+
+      - name: Publish Helm chart to ghcr.io
+        run: |
+          helm package ./deployments/kubernetes/chart/reloader --destination ./packaged-chart
+          helm push ./packaged-chart/*.tgz oci://ghcr.io/stakater/charts
+          rm -rf ./packaged-chart
+
+      - name: Publish Helm chart to gh-pages
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          branch: master
+          repository: stakater-charts
+          target_dir: docs
+          token: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          charts_dir: deployments/kubernetes/chart/
+          charts_url: ${{ env.HELM_REGISTRY_URL }}
+          owner: stakater
+          linting: on
+          commit_username: stakater-user
+          commit_email: stakater@gmail.com
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always() # Pick up events even if the job fails or is canceled.
+        with:
+          status: ${{ job.status }}
+          fields: repo,author,action,eventName,ref,workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -67,10 +67,12 @@ jobs:
           echo "Helm Chart Version wasnt updated"
           exit 1
 
-      # Publish helm chart
-      - name: Login to ghcr via helm
-        run: |
-          echo ${{secrets.GITHUB_TOKEN}} | helm registry login ghcr.io/stakater --username stakater-user --password-stdin
+      - name: Login to GHCR Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io/stakater
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Publish Helm chart to ghcr.io
         run: |
@@ -84,7 +86,7 @@ jobs:
           branch: master
           repository: stakater-charts
           target_dir: docs
-          token: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLISH_TOKEN }}
           charts_dir: deployments/kubernetes/chart/
           charts_url: ${{ env.HELM_REGISTRY_URL }}
           owner: stakater


### PR DESCRIPTION
Workflow for releasing Helm Chart whenever files in the `deployments/kubernetes/chart/reloader/` subdir changes. 