### PR TITLE
Remove chart bump from init release since its not relevant

### DIFF
--- a/.github/workflows/init-branch-release.yaml
+++ b/.github/workflows/init-branch-release.yaml
@@ -48,7 +48,6 @@ jobs:
         run: |
           set -ue
           VERSION=${{ inputs.TARGET_VERSION }} make update-manifests-version
-          VERSION=${{ inputs.TARGET_VERSION }} make bump-chart
           git diff
 
       - name: Generate new set of manifests

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ k8s-manifests: $(KUSTOMIZE) ## Generate k8s manifests using Kustomize from 'mani
 
 .PHONY: update-manifests-version
 update-manifests-version: ## Generate k8s manifests using Kustomize from 'manifests' folder
-	sed -i 's/image: "ghcr.io\/stakater\/reloader:latest"/image: \"ghcr.io\/stakater\/reloader:v$(VERSION)"/g' deployments/kubernetes/manifests/deployment.yaml
+	sed -i 's/image:.*/image: \"ghcr.io\/stakater\/reloader:v$(VERSION)"/g' deployments/kubernetes/manifests/deployment.yaml
 
 # Bump Chart
 bump-chart: 


### PR DESCRIPTION
Init release should only be concerned with the plain k8s manifests and not helm chart, since helm chart has a different release strategy and prematurely bumping that version would be wrong