### PR TITLE
fix: Remove obsolete permissions for apiGroup extensions from helm charts

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -68,16 +68,6 @@ rules:
       - update
       - patch
   - apiGroups:
-      - "extensions"
-    resources:
-      - deployments
-      - daemonsets
-    verbs:
-      - list
-      - get
-      - update
-      - patch
-  - apiGroups:
       - "batch"
     resources:
       - cronjobs


### PR DESCRIPTION
Unfortunately in my last pull request #784 I only removed the deprecated permissions for statefulsets and deployments in the `ClusterRole` only. This pull request removes these permissions for the `Role` as well.