### PR TITLE
chore(helm-templates):support maxUnavailable on pdb resouces

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.2.1
+version: 1.2.2
 appVersion: v1.2.0
 keywords:
   - Reloader

--- a/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
@@ -5,7 +5,12 @@ metadata:
   name: {{ template "reloader-fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
+{{- if .Values.reloader.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.reloader.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- if and .Values.reloader.podDisruptionBudget.minAvailable (not .Values.reloader.podDisruptionBudget.maxUnavailable)}}
   minAvailable: {{ .Values.reloader.podDisruptionBudget.minAvailable }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "reloader-fullname" . }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -288,6 +288,9 @@ reloader:
     enabled: false
     # Set the minimum available replicas
     # minAvailable: 1
+    # OR Set the maximum unavailable replicas
+    # maxUnavailable: 1
+    # If both defined only maxUnavailable will be used
 
   netpol:
     enabled: false


### PR DESCRIPTION
In some deployment "minAvailable" option is causing issues with cluster scaling and maintenance operations.
In those cases "maxUnavailable" option could provide a functional solution.

This change allows users to add maxUnavailable in their values.yaml and PDB will be created using that instead.
If the option is not provided the PDB resource will be created as it was before this change.
