### PR TITLE
rollout update strategy annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ spec:
 - you may want to prevent watching certain resources with the `--resources-to-ignore` flag
 - you can configure logging in JSON format with the `--log-format=json` option
 - you can configure the "reload strategy" with the `--reload-strategy=<strategy-name>` option (details below)
+- you can configure rollout reload strategy with `reloader.stakater.com/rollout-strategy` annotation, `restart` or `rollout` values are available (defaults to `rollout`)
 
 ## Reload Strategies
 

--- a/internal/pkg/callbacks/rolling_upgrade.go
+++ b/internal/pkg/callbacks/rolling_upgrade.go
@@ -2,10 +2,11 @@ package callbacks
 
 import (
 	"context"
-	"time"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stakater/Reloader/internal/pkg/options"
 	"github.com/stakater/Reloader/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -329,11 +330,15 @@ func UpdateDeploymentConfig(clients kube.Clients, namespace string, resource run
 
 // UpdateRollout performs rolling upgrade on rollout
 func UpdateRollout(clients kube.Clients, namespace string, resource runtime.Object) error {
+	var err error
 	rollout := resource.(*argorolloutv1alpha1.Rollout)
-	rolloutBefore, _ := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Get(context.TODO(), rollout.Name, meta_v1.GetOptions{})
-	logrus.Warnf("Before: %+v", rolloutBefore.Spec.Template.Spec.Containers[0].Env)
-	logrus.Warnf("After: %+v", rollout.Spec.Template.Spec.Containers[0].Env)
-	_, err := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Patch(context.TODO(), rollout.Name, patchtypes.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"restartAt": "%s"}}`, time.Now().Format(time.RFC3339))), meta_v1.PatchOptions{FieldManager: "Reloader"})
+	strategy := rollout.GetAnnotations()[options.RolloutStrategyAnnotation]
+	switch options.ToArgoRolloutStrategy(strategy) {
+	case options.RestartStrategy:
+		_, err = clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Patch(context.TODO(), rollout.Name, patchtypes.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"restartAt": "%s"}}`, time.Now().Format(time.RFC3339))), meta_v1.PatchOptions{FieldManager: "Reloader"})
+	case options.RolloutStrategy:
+		_, err = clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Update(context.TODO(), rollout, meta_v1.UpdateOptions{FieldManager: "Reloader"})
+	}
 	return err
 }
 

--- a/internal/pkg/callbacks/rolling_upgrade_test.go
+++ b/internal/pkg/callbacks/rolling_upgrade_test.go
@@ -1,0 +1,105 @@
+package callbacks_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	argorolloutv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	argorollouts "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	watch "k8s.io/apimachinery/pkg/watch"
+
+	"github.com/stakater/Reloader/internal/pkg/callbacks"
+	"github.com/stakater/Reloader/internal/pkg/options"
+	"github.com/stakater/Reloader/internal/pkg/testutil"
+	"github.com/stakater/Reloader/pkg/kube"
+)
+
+var (
+	clients = kube.Clients{ArgoRolloutClient: argorollouts.NewSimpleClientset()}
+)
+
+// TestUpdateRollout test update rollout strategy annotation
+func TestUpdateRollout(t *testing.T) {
+	namespace := "test-ns"
+
+	cases := map[string]struct {
+		name      string
+		strategy  string
+		isRestart bool
+	}{
+		"test-without-strategy": {
+			name:      "defaults to rollout strategy",
+			strategy:  "",
+			isRestart: false,
+		},
+		"test-with-restart-strategy": {
+			name:      "triggers a restart strategy",
+			strategy:  "restart",
+			isRestart: true,
+		},
+		"test-with-rollout-strategy": {
+			name:      "triggers a rollout strategy",
+			strategy:  "rollout",
+			isRestart: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rollout, err := testutil.CreateRollout(
+				clients.ArgoRolloutClient, name, namespace,
+				map[string]string{options.RolloutStrategyAnnotation: tc.strategy},
+			)
+			if err != nil {
+				t.Errorf("creating rollout: %v", err)
+			}
+			modifiedChan := watchRollout(rollout.Name, namespace)
+
+			err = callbacks.UpdateRollout(clients, namespace, rollout)
+			if err != nil {
+				t.Errorf("updating rollout: %v", err)
+			}
+			rollout, err = clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(
+				namespace).Get(context.TODO(), rollout.Name, meta_v1.GetOptions{})
+
+			if err != nil {
+				t.Errorf("getting rollout: %v", err)
+			}
+			if isRestartStrategy(rollout) == tc.isRestart {
+				t.Errorf("Should not be a restart strategy")
+			}
+			select {
+			case <-modifiedChan:
+				// object has been modified
+			case <-time.After(1 * time.Second):
+				t.Errorf("Rollout has not been updated")
+			}
+		})
+	}
+}
+
+func isRestartStrategy(rollout *argorolloutv1alpha1.Rollout) bool {
+	return rollout.Spec.RestartAt == nil
+}
+
+func watchRollout(name, namespace string) chan interface{} {
+	timeOut := int64(1)
+	modifiedChan := make(chan interface{})
+	watcher, _ := clients.ArgoRolloutClient.ArgoprojV1alpha1().Rollouts(namespace).Watch(context.Background(), meta_v1.ListOptions{TimeoutSeconds: &timeOut})
+	go watchModified(watcher, name, modifiedChan)
+	return modifiedChan
+}
+
+func watchModified(watcher watch.Interface, name string, modifiedChan chan interface{}) {
+	for event := range watcher.ResultChan() {
+		item := event.Object.(*argorolloutv1alpha1.Rollout)
+		if item.Name == name {
+			switch event.Type {
+			case watch.Modified:
+				modifiedChan <- nil
+			}
+			return
+		}
+	}
+}

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -2,6 +2,15 @@ package options
 
 import "github.com/stakater/Reloader/internal/pkg/constants"
 
+type ArgoRolloutStrategy int
+
+const (
+	// RestartStrategy is the annotation value for restart strategy for rollouts
+	RestartStrategy ArgoRolloutStrategy = iota
+	// RolloutStrategy is the annotation value for rollout strategy for rollouts
+	RolloutStrategy
+)
+
 var (
 	// Auto reload all resources when their corresponding configmaps/secrets are updated
 	AutoReloadAll = false
@@ -27,6 +36,8 @@ var (
 	// SearchMatchAnnotation is an annotation to tag secrets to be found with
 	// AutoSearchAnnotation
 	SearchMatchAnnotation = "reloader.stakater.com/match"
+	// RolloutStrategyAnnotation is an annotation to define rollout update strategy
+	RolloutStrategyAnnotation = "reloader.stakater.com/rollout-strategy"
 	// LogFormat is the log format to use (json, or empty string for default)
 	LogFormat = ""
 	// LogLevel is the log level to use (trace, debug, info, warning, error, fatal and panic)
@@ -45,3 +56,14 @@ var (
 	// Url to send a request to instead of triggering a reload
 	WebhookUrl = ""
 )
+
+func ToArgoRolloutStrategy(s string) ArgoRolloutStrategy {
+	switch s {
+	case "restart":
+		return RestartStrategy
+	case "rollout":
+		fallthrough
+	default:
+		return RolloutStrategy
+	}
+}


### PR DESCRIPTION
Related to #591 and #724.

Since #724, the `Rollout` update strategy has been changed from "rollout" to "restart". While I can understand that this may be useful in some scenarios, it may not be expected in others.

This MR gives the user the flexibility to choose between a "rollout" or "restart" strategy using an annotation.

