### PR TITLE
Update helm chart to 1.2.1

### DIFF
--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
 
-  helm-validation:
+  helm-chart-validation:
     permissions:
       contents: read
 
@@ -41,6 +41,22 @@ jobs:
       uses: d3adb5/helm-unittest-action@v2
       with:
         charts: deployments/kubernetes/chart/reloader
+
+  helm-version-validation:
+    needs: helm-chart-validation
+
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+    name: Helm Chart Validation
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release/helm-chart' }}
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.event.pull_request.head.sha}}
+        fetch-depth: 0
 
     - name: Add Stakater Helm Repo
       run: |

--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -49,7 +49,7 @@ jobs:
       contents: read
 
     runs-on: ubuntu-latest
-    name: Helm Chart Validation
+    name: Helm Version Validation
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release/helm-chart') }}
 
     steps:

--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -50,7 +50,7 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Helm Chart Validation
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'release/helm-chart' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release/helm-chart') }}
 
     steps:
 

--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -52,6 +52,8 @@ jobs:
     name: Helm Chart Validation
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release/helm-chart' }}
 
+    steps:
+
     - name: Check out code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -15,14 +15,14 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build:
+  verify-and-push-helm-chart:
 
     permissions:
       contents: read
       packages: write # to push artifacts to `ghcr.io`
 
-    name: Build
-    if: github.event.pull_request.merged == true
+    name: Verify and Push Helm Chart
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release/helm-chart')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/push-pr-image.yaml
+++ b/.github/workflows/push-pr-image.yaml
@@ -5,6 +5,15 @@ on:
     branches:
       - master
     types: [ labeled ]
+    paths:
+      - '!.markdownlint.yaml'
+      - '!.vale.ini'
+      - '!Dockerfile-docs'
+      - '!docs-nginx.conf'
+      - '!docs/**'
+      - '!theme_common'
+      - '!theme_override'
+      - '!deployments/kubernetes/chart/reloader/**'
 
 env:
   DOCKER_FILE_PATH: Dockerfile

--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ _Helm chart versioning_: The Reloader Helm chart is maintained in [this reposito
 
 Helm chart will be released to the chart registry whenever files in `deployments/kubernetes/chart/reloader/**` change on the main branch.
 
+Helm Chart will be released by the maintainers, on labelling a PR with `release/helm-chart` and pre-maturely updating the `version` field in `Chart.yaml` file.
+
 ## Changelog
 
 View the [releases page](https://github.com/stakater/Reloader/releases) to see what has changed in each release.

--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
 version: 1.2.1
-appVersion: v1.2.0
+appVersion: v1.2.1
 keywords:
   - Reloader
   - kubernetes

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -96,11 +96,11 @@ reloader:
     labels:
       provider: stakater
       group: com.stakater.platform
-      version: v1.2.0
+      version: v1.2.1
     image:
       name: ghcr.io/stakater/reloader
       base: stakater/reloader
-      tag: v1.2.0
+      tag: v1.2.1
       pullPolicy: IfNotPresent
     # Support for extra environment variables.
     env:


### PR DESCRIPTION
With this PR, responsibility of updating Chart.yaml file when a helm chart release is needed is shifted to maintainers of this repo. 

The process will now be as follows:

1. merge all the helm chart related PRs into master branch
2. create a new PR with chart.yaml version updates, by prematurely updating helm version with the expected to-be-released version
3. label this PR with `release/helm-chart`
4. after validation passes on PR, merge it to get a released helm chart