### PR TITLE
No need to build images for multiple platforms for docs

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -200,7 +200,6 @@ jobs:
           push: true
           build-args: BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
           cache-to: type=inline
-          platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}/docs:merge-${{ github.event.number }}
           labels: |


### PR DESCRIPTION
It [errors out](https://github.com/stakater/Reloader/actions/runs/13309798344/job/37173746325) anyway with `ERROR: Failed building wheel for regex` for linux/arm/v7