### PR TITLE
Dispatch tag

### DIFF
--- a/.github/workflows/reloader-enterprise-published.yml
+++ b/.github/workflows/reloader-enterprise-published.yml
@@ -14,4 +14,4 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.STAKATER_AB_TOKEN_FOR_RLDR }}" \
           https://api.github.com/repos/stakater-ab/reloader-enterprise/dispatches \
-          -d '{"event_type":"release-published"}'
+          -d '{"event_type":"release-published","client_payload":{"tag":"${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
For the release dispatch workflow, the release tag seems to never be included on the receiving end, `github.event.release.tag_name` is empty in the receiving workflow. It will be sent separately via a client payload with this change.