### PR TITLE
ci(helm): cosign OCI helm chart

### DIFF
--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -68,6 +68,9 @@ jobs:
           echo "Helm Chart Version wasnt updated"
           exit 1
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.1
+
       - name: Login to GHCR Registry
         uses: docker/login-action@v3
         with:
@@ -80,6 +83,9 @@ jobs:
           helm package ./deployments/kubernetes/chart/reloader --destination ./packaged-chart
           helm push ./packaged-chart/*.tgz oci://ghcr.io/stakater/charts
           rm -rf ./packaged-chart
+
+      - name: Sign artifacts with Cosign
+        run: cosign sign --yes ghcr.io/stakater/charts/reloader:${{ steps.new_chart_version.outputs.result }}
 
       - name: Publish Helm chart to gh-pages
         uses: stefanprodan/helm-gh-pages@master

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -18,8 +18,9 @@ jobs:
   verify-and-push-helm-chart:
 
     permissions:
-      contents: read
-      packages: write # to push artifacts to `ghcr.io`
+      contents: write # needed to pull git repo and create "chart-release"
+      id-token: write # needed for signing the images with GitHub OIDC Token
+      packages: write # for pushing and signing container images
 
     name: Verify and Push Helm Chart
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release/helm-chart')) }}

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -18,7 +18,7 @@ jobs:
   verify-and-push-helm-chart:
 
     permissions:
-      contents: write # needed to pull git repo and create "chart-release"
+      contents: read
       id-token: write # needed for signing the images with GitHub OIDC Token
       packages: write # for pushing and signing container images
 


### PR DESCRIPTION
This allows for the OCI Helm chart to be verified on our end using keyless verification.

You can read more about it https://fluxcd.io/blog/2022/11/verify-the-integrity-of-the-helm-charts-stored-as-oci-artifacts-before-reconciling-them-with-flux/