### PR TITLE
Push 2.0.0 helm chart

### DIFF
--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -1,5 +1,7 @@
 name: Pull Request Workflow for Helm Chart changes
 
+# TODO: fix: workflows have a problem where only code owners' PRs get the actions running 
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
workflows have a problem where only code owners' PRs get the actions running 