### PR TITLE
Add OwnerReference to generated Jobs

### DIFF
--- a/internal/pkg/callbacks/rolling_upgrade.go
+++ b/internal/pkg/callbacks/rolling_upgrade.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 
+	"maps"
+
 	argorolloutv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 )
 
@@ -443,11 +445,16 @@ func PatchDeployment(clients kube.Clients, namespace string, resource runtime.Ob
 // CreateJobFromCronjob performs rolling upgrade on cronjob
 func CreateJobFromCronjob(clients kube.Clients, namespace string, resource runtime.Object) error {
 	cronJob := resource.(*batchv1.CronJob)
+
+	annotations := make(map[string]string)
+	annotations["cronjob.kubernetes.io/instantiate"] = "manual"
+	maps.Copy(annotations, cronJob.Spec.JobTemplate.Annotations)
+
 	job := &batchv1.Job{
 		ObjectMeta: meta_v1.ObjectMeta{
 			GenerateName:    cronJob.Name + "-",
 			Namespace:       cronJob.Namespace,
-			Annotations:     cronJob.Spec.JobTemplate.Annotations,
+			Annotations:     annotations,
 			Labels:          cronJob.Spec.JobTemplate.Labels,
 			OwnerReferences: []meta_v1.OwnerReference{*meta_v1.NewControllerRef(cronJob, batchv1.SchemeGroupVersion.WithKind("CronJob"))},
 		},


### PR DESCRIPTION
Since https://github.com/stakater/Reloader/pull/486 Reloader is able to trigger Jobs from existing CronJob, which is awesome :tada: 

But I noticed that the generated Jobs are missing [owner references](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications) to the CronJob that was used to create them. This creates some issues:

* The created jobs are not deleted when the CronJob is deleted.
* The created jobs are not displayed in tools like ArgoCD or K9s.

Prior art:

* kubectl: https://github.com/kubernetes/kubectl/blob/5e1a193aef164bbd16b770684ff7711c6beed7d4/pkg/cmd/create/create_job.go#L268
* Kubernetes Dashboard: https://github.com/kubernetes/dashboard/blob/ee8b965861da0e6e6c3c764b91b7824f92383e15/modules/api/pkg/resource/cronjob/jobs.go#L121
* K9s: https://github.com/derailed/k9s/blob/39eef03373871388fc3cf2fa434d055e1eb97319/internal/dao/cronjob.go#L80
* ArgoCD: https://github.com/argoproj/argo-cd/blob/fe598a831e42a2838242f99d6a74be520f27908a/resource_customizations/batch/CronJob/actions/create-job/action.lua#L46

I successfully tested this change in one of our clusters.