### PR TITLE
Helm chart update for v1.4.0

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 2.0.0
-appVersion: v1.3.0
+version: 2.1.0
+appVersion: v1.4.0
 keywords:
   - Reloader
   - kubernetes

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 image:
   name: stakater/reloader
   repository: ghcr.io/stakater/reloader
-  tag: v1.3.0
+  tag: v1.4.0
   # digest: sha256:1234567
   pullPolicy: IfNotPresent
 
@@ -106,7 +106,7 @@ reloader:
     labels:
       provider: stakater
       group: com.stakater.platform
-      version: v1.3.0
+      version: v1.4.0
     # Support for extra environment variables.
     env:
       # Open supports Key value pair as environment variables.


### PR DESCRIPTION
Bumping the chart version due to it now containing a README among other things, see the release notes for 1.4.0