### PR TITLE
Fix matchLabels for selector

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
   revisionHistoryLimit: {{ .Values.reloader.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
-      release: {{ .Release.Name | quote }}
+      app.kubernetes.io/name: {{ template "reloader-fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -14,8 +14,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
-      release: {{ .Release.Name | quote }}
+      app.kubernetes.io/name: {{ template "reloader-fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
@@ -13,5 +13,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
+      app.kubernetes.io/name: {{ template "reloader-fullname" . }}
 {{- end }}


### PR DESCRIPTION
Fix error:
```shell
Error: INSTALLATION FAILED: 1 error occurred:
	* Deployment.apps "reloader" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/instance":"reloader", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"reloader", "app.kubernetes.io/version":"v1.4.0", "group":"com.stakater.platform", "helm.sh/chart":"reloader-2.0.0", "provider":"stakater", "version":"v1.4.0"}: `selector` does not match template `labels`
```