### PR TITLE
vanilla-manifests: use 'imagePullPolicy: Always' for latest tag

### DIFF
--- a/deployments/kubernetes/reloader.yaml
+++ b/deployments/kubernetes/reloader.yaml
@@ -105,7 +105,7 @@ spec:
               divisor: "1"
               resource: limits.memory
         image: "ghcr.io/stakater/reloader:latest"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:


### PR DESCRIPTION
With lastest tag it's expected that latest version will be used, with 'imagePullPolicy: IfNotPresent' the previously deployed version could be used.