### PR TITLE
[helm] Add templating support for additionals labels

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
-{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.rbac.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role
 rules:

--- a/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrolebinding.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
-{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.rbac.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role-binding
 roleRef:

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -4,15 +4,16 @@ metadata:
   annotations:
 {{ include "reloader-helm3.annotations" . | indent 4 }}
 {{- if .Values.reloader.deployment.annotations }}
-{{ toYaml .Values.reloader.deployment.annotations | indent 4 }}
+{{ tpl (toYaml .Values.reloader.deployment.annotations) . | indent 4 }}
 {{- end }}
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.deployment.labels }}
-{{ toYaml .Values.reloader.deployment.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.deployment.labels) . | indent 4 }}
+    dupa3: {{ .Chart.Name }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
@@ -28,21 +29,21 @@ spec:
       app: {{ template "reloader-fullname" . }}
       release: {{ .Release.Name | quote }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 6 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 6 }}
 {{- end }}
   template:
     metadata:
 {{- if .Values.reloader.deployment.pod.annotations }}
       annotations:
-{{ toYaml .Values.reloader.deployment.pod.annotations | indent 8 }}
+{{ tpl (toYaml .Values.reloader.deployment.pod.annotations) . | indent 8 }}
 {{- end }}
       labels:
 {{ include "reloader-labels.chart" . | indent 8 }}
 {{- if .Values.reloader.deployment.labels }}
-{{ toYaml .Values.reloader.deployment.labels | indent 8 }}
+{{ tpl (toYaml .Values.reloader.deployment.labels) . | indent 8 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 8 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 8 }}
 {{- end }}
     spec:
       {{- with .Values.global.imagePullSecrets }}

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.deployment.labels }}
 {{ tpl (toYaml .Values.reloader.deployment.labels) . | indent 4 }}
-    dupa3: {{ .Chart.Name }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
 {{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
@@ -17,7 +17,7 @@ spec:
       app: {{ template "reloader-fullname" . }}
       release: {{ .Release.Name | quote }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 6 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 6 }}
 {{- end }}
   policyTypes:
   - Ingress

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
-{{ tpl (toYaml .Values.reloader.rbac.labels) | indent 4 }}
+{{ tpl (toYaml .Values.reloader.rbac.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ tpl (toYaml .Values.reloader.matchLabels) | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role
   namespace: {{ .Values.namespace | default .Release.Namespace }}

--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
-{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.rbac.labels) | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role
   namespace: {{ .Values.namespace | default .Release.Namespace }}

--- a/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/rolebinding.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
-{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.rbac.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}-role-binding
   namespace: {{ .Values.namespace | default .Release.Namespace }}

--- a/deployments/kubernetes/chart/reloader/templates/service.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/service.yaml
@@ -5,22 +5,22 @@ metadata:
   annotations:
 {{ include "reloader-helm3.annotations" . | indent 4 }}
 {{- if .Values.reloader.service.annotations }}
-{{ toYaml .Values.reloader.service.annotations | indent 4 }}
+{{ tpl (toYaml .Values.reloader.service.annotations) . | indent 4 }}
 {{- end }}
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.service.labels }}
-{{ toYaml .Values.reloader.service.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.service.labels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   selector:
 {{- if .Values.reloader.deployment.labels }}
-{{ toYaml .Values.reloader.deployment.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.deployment.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   ports:
   - port: {{ .Values.reloader.service.port }}

--- a/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/serviceaccount.yaml
@@ -11,15 +11,15 @@ metadata:
   annotations:
 {{ include "reloader-helm3.annotations" . | indent 4 }}
 {{- if .Values.reloader.serviceAccount.annotations }}
-{{ toYaml .Values.reloader.serviceAccount.annotations | indent 4 }}
+{{ tpl (toYaml .Values.reloader.serviceAccount.annotations) . | indent 4 }}
 {{- end }}
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
 {{- if .Values.reloader.serviceAccount.labels }}
-{{ toYaml .Values.reloader.serviceAccount.labels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.serviceAccount.labels) . | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
-{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{ tpl (toYaml .Values.reloader.matchLabels) . | indent 4 }}
 {{- end }}
   name: {{ template "reloader-serviceAccountName" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}


### PR DESCRIPTION
Everything is in the title ⬆️

It's aligned with what has been done in this commit for the ServiceMonitor: https://github.com/stakater/Reloader/commit/1f2d75898be72ace650647e4d15fb22c44e2731f

Goal is to support values with helm-template inside, like:

```
reloader:
  deployment:
    labels:
      anotherChartLabel: 'the chart name is {{ .Chart.Name }}'
```

To have the label rendered in the manifest:

```
    labels:
      [...]
      anotherChartLabel: the chart name is reloader
```

Regards