### PR TITLE
Use labels suggested by Kubernetes and Helm best practices

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 2.1.5
+version: 2.2.0
 appVersion: v1.4.5
 keywords:
   - Reloader

--- a/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
+++ b/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
@@ -27,12 +27,20 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{- define "reloader-labels.chart" -}}
+{{- define "reloader-match-labels.chart" -}}
 app: {{ template "reloader-fullname" . }}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 release: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{- define "reloader-labels.chart" -}}
+{{ include "reloader-match-labels.chart" . }}
+app.kubernetes.io/name: {{ template "reloader-name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 heritage: {{ .Release.Service | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end -}}
 
 {{/*
@@ -45,10 +53,10 @@ podAntiAffinity:
     podAffinityTerm:
       labelSelector:
         matchExpressions:
-        - key: app
+        - key: app.kubernetes.io/instance
           operator: In
           values:
-          - {{ template "reloader-fullname" . }}
+          - {{ .Release.Name | quote }}
       topologyKey: "kubernetes.io/hostname"
 {{- end -}}
 

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -25,8 +25,7 @@ spec:
   revisionHistoryLimit: {{ .Values.reloader.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
-      release: {{ .Release.Name | quote }}
+{{ include "reloader-match-labels.chart" . | indent 6 }}
 {{- if .Values.reloader.matchLabels }}
 {{ tpl (toYaml .Values.reloader.matchLabels) . | indent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/networkpolicy.yaml
@@ -14,8 +14,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
-      release: {{ .Release.Name | quote }}
+{{ include "reloader-match-labels.chart" . | indent 6 }}
 {{- if .Values.reloader.matchLabels }}
 {{ tpl (toYaml .Values.reloader.matchLabels) . | indent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/poddisruptionbudget.yaml
@@ -13,5 +13,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: {{ template "reloader-fullname" . }}
+      {{ include "reloader-match-labels.chart" . | nindent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/podmonitor.yaml
@@ -56,5 +56,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{ include "reloader-labels.chart" . | nindent 6 }}
+      {{ include "reloader-match-labels.chart" . | nindent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/servicemonitor.yaml
@@ -56,5 +56,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{ include "reloader-labels.chart" . | nindent 6 }}
+      {{ include "reloader-match-labels.chart" . | nindent 6 }}
 {{- end }}

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -99,7 +99,7 @@ reloader:
     #     whenUnsatisfiable: DoNotSchedule
     #     labelSelector:
     #       matchLabels:
-    #         app: my-app
+    #         app.kubernetes.io/instance: my-app
     topologySpreadConstraints: []
 
     annotations: {}


### PR DESCRIPTION
Close https://github.com/stakater/Reloader/issues/496 Splited from #932 

This improves the compatibility and makes it easier to work with various tools, which take advantake from the assumption of existence of those labels.

* https://helm.sh/docs/chart_best_practices/labels/
* https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Keep the old labels for selectors for backward compatibility.

Also note there is slight change in behaviour of PDB which might be backward-incompatible in some rare cases, but it is IMHO edge-case when the release name changes and someone for some obscure reason depends on not scheduling the new pods to same K8s node as the old pod, so I consider this change benign.

The chart was tested with the following values:

```
reloader:
  deployment:
    replicas: 2
    priorityClassName:
  enableHA: true
  logFormat: json
  podDisruptionBudget:
    enabled: true
  podMonitor:
    enabled: true
  readOnlyRootFileSystem: true
  reloadOnCreate: true
```