### PR TITLE
Added pprof flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,10 @@ These flags allow you to redefine annotation keys used in your workloads or reso
 
 ### 5. 🕷️ Debugging
 
-Flag | Description 
----  |---
-`--enable-pprof` | Enables pprof for profiling
-`--pprof-addr` | Address to start pprof server on. Default is `:6060`
+| Flag | Description |
+|---  |-------------|
+| `--enable-pprof` | Enables `pprof` for profiling |
+| `--pprof-addr` | Address to start `pprof` server on. Default is `:6060` |
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ These flags allow you to redefine annotation keys used in your workloads or reso
 | `--pause-deployment-annotation` | Overrides `deployment.reloader.stakater.com/pause-period` |
 | `--pause-deployment-time-annotation` | Overrides `deployment.reloader.stakater.com/paused-at` |
 
+### 5. 🕷️ Debugging
+
+Flag | Description 
+---  |---
+`--enable-pprof` | Enables pprof for profiling
+`--pprof-addr` | Address to start pprof server on. Default is `:6060`
+
 ## Compatibility
 
 Reloader is compatible with Kubernetes >= 1.19

--- a/deployments/kubernetes/chart/reloader/README.md
+++ b/deployments/kubernetes/chart/reloader/README.md
@@ -57,6 +57,8 @@ helm uninstall {{RELEASE_NAME}} -n {{NAMESPACE}}
 | `reloader.logFormat`                | Set type of log format. Value could be either `json` or `""`                                                                                        | string      | `""`      |
 | `reloader.watchGlobally`            | Allow Reloader to watch in all namespaces (`true`) or just in a single namespace (`false`)                                                          | boolean     | `true`    |
 | `reloader.enableHA`                 | Enable leadership election allowing you to run multiple replicas                                                                                    | boolean     | `false`   |
+| `reloader.enablePProf`              | Enables pprof for profiling | boolean | `false` |
+| `reloader.pprofAddr` | Address to start pprof server on | string | `:6060` | 
 | `reloader.readOnlyRootFileSystem`   | Enforce readOnlyRootFilesystem                                                                                                                      | boolean     | `false`   |
 | `reloader.legacy.rbac`              |                                                                                                                                                     | boolean     | `false`   |
 | `reloader.matchLabels`              | Pod labels to match                                                                                                                                 | map         | `{}`      |

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -229,6 +229,12 @@ spec:
           {{- if .Values.reloader.resourceLabelSelector }}
           - "--resource-label-selector={{ .Values.reloader.resourceLabelSelector }}"
           {{- end }}
+          {{- if .Values.reloader.enablePProf }}
+          - "--enable-pprof"
+          {{- if and .Values.reloader.pprofAddr }}
+          - "--pprof-addr={{ .Values.reloader.pprofAddr }}"
+          {{- end }}
+          {{- end }}
           {{- if .Values.reloader.custom_annotations }}
             {{- if .Values.reloader.custom_annotations.configmap }}
           - "--configmap-annotation"

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -41,6 +41,10 @@ reloader:
   watchGlobally: true
   # Set to true to enable leadership election allowing you to run multiple replicas
   enableHA: false
+  # Set to true to enable pprof for profiling
+  enablePProf: false
+  # Address to start pprof server on. Default is ":6060"
+  pprofAddr: ":6060"
   # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
   readOnlyRootFileSystem: false
   legacy:

--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strings"
 
@@ -192,6 +193,17 @@ func startReloader(cmd *cobra.Command, args []string) {
 
 	common.PublishMetaInfoConfigmap(clientset)
 
+	if options.EnablePProf {
+		go startPProfServer()
+	}
+
 	leadership.SetupLivenessEndpoint()
 	logrus.Fatal(http.ListenAndServe(constants.DefaultHttpListenAddr, nil))
+}
+
+func startPProfServer() {
+	logrus.Infof("Starting pprof server on %s", options.PProfAddr)
+	if err := http.ListenAndServe(options.PProfAddr, nil); err != nil {
+		logrus.Errorf("Failed to start pprof server: %v", err)
+	}
 }

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -74,8 +74,8 @@ var (
 	// EnablePProf enables pprof for profiling
 	EnablePProf = false
 	// PProfAddr is the address to start pprof server on
-	// Default is localhost:6060
-	PProfAddr = "localhost:6060"
+	// Default is :6060
+	PProfAddr = ":6060"
 )
 
 func ToArgoRolloutStrategy(s string) ArgoRolloutStrategy {

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -63,14 +63,19 @@ var (
 	EnableHA = false
 	// Url to send a request to instead of triggering a reload
 	WebhookUrl = ""
-
+	// ResourcesToIgnore is a list of resources to ignore when watching for changes
 	ResourcesToIgnore = []string{}
-
+	// NamespacesToIgnore is a list of namespace names to ignore when watching for changes
 	NamespacesToIgnore = []string{}
-
+	// NamespaceSelectors is a list of namespace selectors to watch for changes
 	NamespaceSelectors = []string{}
-
+	// ResourceSelectors is a list of resource selectors to watch for changes
 	ResourceSelectors = []string{}
+	// EnablePProf enables pprof for profiling
+	EnablePProf = false
+	// PProfAddr is the address to start pprof server on
+	// Default is localhost:6060
+	PProfAddr = "localhost:6060"
 )
 
 func ToArgoRolloutStrategy(s string) ArgoRolloutStrategy {

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -94,6 +94,8 @@ func ConfigureReloaderFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&options.ReloadOnDelete, "reload-on-delete", "false", "Add support to watch delete events")
 	cmd.PersistentFlags().BoolVar(&options.EnableHA, "enable-ha", false, "Adds support for running multiple replicas via leadership election")
 	cmd.PersistentFlags().BoolVar(&options.SyncAfterRestart, "sync-after-restart", false, "Sync add events after reloader restarts")
+	cmd.PersistentFlags().BoolVar(&options.EnablePProf, "enable-pprof", false, "Enable pprof for profiling")
+	cmd.PersistentFlags().StringVar(&options.PProfAddr, "pprof-addr", ":6060", "Address to start pprof server on. Default is :6060")
 }
 
 func GetNamespaceLabelSelector() (string, error) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -80,6 +80,10 @@ type ReloaderOptions struct {
 	ResourceSelectors []string `json:"resourceSelectors"`
 	// NamespacesToIgnore is a list of namespace names to ignore when watching for changes
 	NamespacesToIgnore []string `json:"namespacesToIgnore"`
+	// EnablePProf enables pprof for profiling
+	EnablePProf bool `json:"enablePProf"`
+	// PProfAddr is the address to start pprof server on
+	PProfAddr string `json:"pprofAddr"`
 }
 
 var CommandLineOptions *ReloaderOptions
@@ -253,6 +257,7 @@ func GetCommandLineOptions() *ReloaderOptions {
 	CommandLineOptions.IsArgoRollouts = parseBool(options.IsArgoRollouts)
 	CommandLineOptions.ReloadOnCreate = parseBool(options.ReloadOnCreate)
 	CommandLineOptions.ReloadOnDelete = parseBool(options.ReloadOnDelete)
+	CommandLineOptions.EnablePProf = options.EnablePProf
 
 	return CommandLineOptions
 }


### PR DESCRIPTION
Added flags to enable pprof and configure binding port

Flag | Description 
---  |---
`--enable-pprof` | Enables pprof for profiling
`--pprof-addr` | Address to start pprof server on. Default is `:6060`