### PR TITLE
fix: handle operator crash when using workloadRef

### DIFF
--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -417,7 +417,11 @@ func getContainerUsingResource(upgradeFuncs callbacks.RollingUpgradeFuncs, item 
 			container = getContainerWithVolumeMount(initContainers, volumeMountName)
 			if container != nil {
 				// if configmap/secret is being used in init container then return the first Pod container to save reloader env
-				return &containers[0]
+				if len(containers) > 0 {
+					return &containers[0]
+				}
+				// No containers available, return nil to avoid crash
+				return nil
 			}
 		} else if container != nil {
 			return container
@@ -430,13 +434,21 @@ func getContainerUsingResource(upgradeFuncs callbacks.RollingUpgradeFuncs, item 
 		container = getContainerWithEnvReference(initContainers, config.ResourceName, config.Type)
 		if container != nil {
 			// if configmap/secret is being used in init container then return the first Pod container to save reloader env
-			return &containers[0]
+			if len(containers) > 0 {
+				return &containers[0]
+			}
+			// No containers available, return nil to avoid crash
+			return nil
 		}
 	}
 
 	// Get the first container if the annotation is related to specified configmap or secret i.e. configmap.reloader.stakater.com/reload
 	if container == nil && !autoReload {
-		return &containers[0]
+		if len(containers) > 0 {
+			return &containers[0]
+		}
+		// No containers available, return nil to avoid crash
+		return nil
 	}
 
 	return container


### PR DESCRIPTION
Description
This MR fixes issue #751 where restarting an Argo Rollout configured with workloadRef causes the Reloader operator pod to crash with a panic: "runtime error: index out of range [0] with length 0".

Root Cause
The issue occurs because Argo Rollouts using workloadRef reference an existing Deployment/ReplicaSet instead of defining containers directly in their Spec.Template.Spec.Containers. When the GetRolloutContainers function is called for such rollouts, it returns an empty slice since no containers are defined in the rollout template itself.

The panic happens in the getContainerUsingResource function in [upgrade.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) when the code attempts to access containers[0] without first checking if the slice contains any elements.

Solution
Added bounds checking before accessing the first element of the containers slice to prevent index out of range panics.

Related Issues
Closes #751