### PR TITLE
Clarify PR process for Helm chart version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ To make a GitHub release:
 1. Code owners run a dispatch mode workflow to automatically generate version and manifests on the release branch
 1. A PR is created to bump the image version on the release branch, example: [PR-798](https://github.com/stakater/Reloader/pull/798)
 1. Code owners create a GitHub release with tag `vX.Y.Z` and target branch `release-vX.Y.Z`, which triggers creation of images
-1. Code owners create a PR to update the Helm chart version, example: [PR-846](https://github.com/stakater/Reloader/pull/846)
+1. Code owners create a PR with `release/helm-chart` label to update the Helm chart version, example: [PR-846](https://github.com/stakater/Reloader/pull/846)
 
 _Repository git tagging_: Push to the main branch will create a merge-image and merge-tag named `merge-${{ github.event.number }}`, for example `merge-800` when pull request number 800 is merged.
 


### PR DESCRIPTION
Updated instructions for creating a PR to include a specific label for Helm chart version updates.