### PR TITLE
fix: bump go version to fix CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stakater/Reloader
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/argoproj/argo-rollouts v1.8.2


### PR DESCRIPTION
Opening PR to fix 2 CVEs that are detected on go 1.24.5 and below:

<img width="1257" height="635" alt="image" src="https://github.com/user-attachments/assets/bf4fd842-294e-4ec5-8dbd-12cb08a38fcc" />

- https://nvd.nist.gov/vuln/detail/CVE-2025-4674
- https://nvd.nist.gov/vuln/detail/CVE-2025-47907

bumping go version to `1.24.6` fixes both CVEs