### PR TITLE
fix the value reference to runAsUser for OpenShift

### DIFF
--- a/deployments/kubernetes/chart/reloader/README.md
+++ b/deployments/kubernetes/chart/reloader/README.md
@@ -132,7 +132,7 @@ helm uninstall {{RELEASE_NAME}} -n {{NAMESPACE}}
 ### OpenShift Considerations
 - Recent OpenShift versions (tested on 4.13.3) require:
   - Users to be in a dynamically assigned UID range
-  - **Solution**: Unset `runAsUser` via `deployment.securityContext.runAsUser=null`
+  - **Solution**: Unset `runAsUser` via `reloader.deployment.securityContext.runAsUser=null`
   - Let OpenShift assign UID automatically during installation
 
 ### Core Functionality Flags


### PR DESCRIPTION
The chart README is incorrect in the runAsUser fix for openshift. I have corrected it and want to merge.

This PR contains:
Fix the value reference in the README documentation so it matches the chart value in `values.yaml`.