### PR TITLE
fix: bump go version to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE
 ARG BASE_IMAGE
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.24.6} AS builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.24.9} AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stakater/Reloader
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/argoproj/argo-rollouts v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.32.3 h1:VMi584rbboso+yjfv0d8uBHwwxbC438LKq+dXd5tOAI=
 k8s.io/kubectl v0.32.3/go.mod h1:6Euv2aso5GKzo/UVMacV6C7miuyevpfI91SvBvV9Zdg=
-k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e h1:KqK5c/ghOm8xkHYhlodbp6i6+r+ChV2vuAuVRdFbLro=
-k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=


### PR DESCRIPTION
Opening PR to fix several CVEs that are detected on go 1.24.6 and below:

<img width="1257" height="1072" alt="image" src="https://github.com/user-attachments/assets/262da543-57cc-46ed-a97a-642bfcd10eb0" />

- https://nvd.nist.gov/vuln/detail/CVE-2025-61725
- https://nvd.nist.gov/vuln/detail/CVE-2025-47912
- https://nvd.nist.gov/vuln/detail/CVE-2025-58186
- https://nvd.nist.gov/vuln/detail/CVE-2025-61724
- https://nvd.nist.gov/vuln/detail/CVE-2025-58188
- https://nvd.nist.gov/vuln/detail/CVE-2025-61723
- https://nvd.nist.gov/vuln/detail/CVE-2025-58189
- https://nvd.nist.gov/vuln/detail/CVE-2025-58185
- https://nvd.nist.gov/vuln/detail/CVE-2025-58187
- https://nvd.nist.gov/vuln/detail/CVE-2025-58183

bumping go version to `1.24.9` fixes all the CVEs