### PR TITLE
fix:Rename pause-deployment-annotation to pause-deployment-time-annot…

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -280,7 +280,7 @@ spec:
           - "{{ .Values.reloader.custom_annotations.pausePeriod }}"
             {{- end }}
             {{- if .Values.reloader.custom_annotations.pauseTime }}
-          - "--pause-deployment-annotation"
+          - "--pause-deployment-time-annotation"
           - "{{ .Values.reloader.custom_annotations.pauseTime }}"
             {{- end }}
             {{- if .Values.reloader.webhookUrl }}


### PR DESCRIPTION
Hi team,

This PR fixes a small bug in the Helm chart's deployment template where the `--pause-deployment-time-annotation` was incorrectly using the `--pause-deployment-annotation` flag.

This change correctly maps the `pauseTime` value to its intended `--pause-deployment-time-annotation` argument.

Closes #1048