### PR TITLE
add linux nodeselector

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
       {{- end }}
       {{- if .Values.reloader.deployment.nodeSelector }}
       nodeSelector:
+        "kubernetes.io/os": linux
 {{ toYaml .Values.reloader.deployment.nodeSelector | indent 8 }}
       {{- end }}
       {{- if or (.Values.reloader.deployment.affinity) (.Values.reloader.enableHA) }}

--- a/deployments/kubernetes/chart/reloader/tests/deployment_test.yaml
+++ b/deployments/kubernetes/chart/reloader/tests/deployment_test.yaml
@@ -4,6 +4,13 @@ templates:
   - deployment.yaml
 
 tests:
+  - it: sets nodeSelector to linux only
+    set:
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector."kubernetes.io/os"
+          value: linux
+
   - it: sets readOnlyRootFilesystem in container securityContext when reloader.readOnlyRootFileSystem is true
     set:
       reloader:

--- a/deployments/kubernetes/manifests/deployment.yaml
+++ b/deployments/kubernetes/manifests/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app: reloader-reloader
     spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
       containers:
         - image: "ghcr.io/stakater/reloader:v1.4.10"
           imagePullPolicy: IfNotPresent

--- a/deployments/kubernetes/reloader.yaml
+++ b/deployments/kubernetes/reloader.yaml
@@ -123,6 +123,8 @@ spec:
       labels:
         app: reloader-reloader
     spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
       containers:
       - env:
         - name: GOMAXPROCS


### PR DESCRIPTION
While running Reloader in my cluster, the pod was deployed to a windows node and failed as the image doesn't support windows.

This PR adds a node selector to the pod so it will only be scheduled on Linux nodes.

Related to https://github.com/stakater/Reloader/issues/368

### Pods

```
tim@wrightt-laptop:~/git/Reloader$ kubectl get pods -o wide
NAME                                 READY   STATUS         RESTARTS   AGE   IP             NODE              NOMINATED NODE   READINESS GATES
hpc-2019-85jsr                       1/1     Running        0          31m   10.224.0.5     aksws2019000000   <none>           <none>
hpc-2022-vxnpt                       1/1     Running        0          33m   10.224.0.10    aksws2022000003   <none>           <none>
hpc-2025-2022-cbdd8                  1/1     Running        0          33m   10.224.0.11    aksws2025000000   <none>           <none>
hpc-2025-dtkv9                       1/1     Running        0          31m   10.224.0.11    aksws2025000000   <none>           <none>
hpc-23h2-ldphj                       1/1     Running        0          33m   10.224.0.7     akswsannu000000   <none>           <none>
reloader-reloader-5877c96d8f-wfb79   0/1     ErrImagePull   0          11m   172.16.0.181   aksws2019000000   <none>           <none>
windows-updates-6g9n6                1/1     Running        0          14m   10.224.0.11    aksws2025000000   <none>           <none>
windows-updates-hr9jr                1/1     Running        0          14m   10.224.0.7     akswsannu000000   <none>           <none>
windows-updates-kxjsq                1/1     Running        0          14m   10.224.0.5     aksws2019000000   <none>           <none>
windows-updates-lfbmv                1/1     Running        0          14m   10.224.0.10    aksws2022000003   <none>           <none>
```

### Logs

```
tim@wrightt-laptop:~/git/Reloader$ kubectl logs reloader-reloader-5877c96d8f-wfb79
Error from server (BadRequest): container "reloader-reloader" in pod "reloader-reloader-5877c96d8f-wfb79" is waiting to start: trying and failing to pull image
```

### Describe Container

```
tim@wrightt-laptop:~/git/Reloader$ kubectl describe pod reloader-reloader-5877c96d8f-wfb79
Name:             reloader-reloader-5877c96d8f-wfb79
Namespace:        default
Priority:         0
Service Account:  reloader-reloader
Node:             aksws2019000000/10.224.0.5
Start Time:       Sat, 08 Nov 2025 10:10:39 +1300
Labels:           app=reloader-reloader
                  app.kubernetes.io/instance=reloader
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=reloader
                  app.kubernetes.io/version=v1.4.10
                  chart=reloader-2.2.5
                  group=com.stakater.platform
                  helm.sh/chart=reloader-2.2.5
                  heritage=Helm
                  pod-template-hash=5877c96d8f
                  provider=stakater
                  release=reloader
                  version=v1.4.10
Annotations:      <none>
Status:           Pending
SeccompProfile:   RuntimeDefault
IP:               172.16.0.181
IPs:
  IP:           172.16.0.181
Controlled By:  ReplicaSet/reloader-reloader-5877c96d8f
Containers:
  reloader-reloader:
    Container ID:
    Image:         ghcr.io/stakater/reloader:v1.4.10
    Image ID:
    Port:          9090/TCP
    Host Port:     0/TCP
    Args:
      --log-level=info
    State:          Waiting
      Reason:       ImagePullBackOff
    Ready:          False
    Restart Count:  0
    Liveness:       http-get http://:http/live delay=10s timeout=5s period=10s #success=1 #failure=5
    Readiness:      http-get http://:http/metrics delay=10s timeout=5s period=10s #success=1 #failure=5
    Environment:
      GOMAXPROCS:                node allocatable (limits.cpu)
      GOMEMLIMIT:                node allocatable (limits.memory)
      RELOADER_NAMESPACE:        default (v1:metadata.namespace)
      RELOADER_DEPLOYMENT_NAME:  reloader-reloader
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-7j6kg (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       False
  ContainersReady             False
  PodScheduled                True
Volumes:
  kube-api-access-7j6kg:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  10m                  default-scheduler  Successfully assigned default/reloader-reloader-5877c96d8f-wfb79 to aksws2019000000
  Normal   Pulling    7m21s (x5 over 10m)  kubelet            Pulling image "ghcr.io/stakater/reloader:v1.4.10"
  Warning  Failed     7m20s (x5 over 10m)  kubelet            Failed to pull image "ghcr.io/stakater/reloader:v1.4.10": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/stakater/reloader:v1.4.10": no match for platform in manifest: not found
  Warning  Failed     7m20s (x5 over 10m)  kubelet            Error: ErrImagePull
  Normal   BackOff    15s (x42 over 10m)   kubelet            Error: ImagePullBackOff
```

