### PR TITLE
Fix configmaps key in ResourceMap leading to controllers not being able to mark themselves as initialized

### DIFF
--- a/pkg/kube/resourcemapper.go
+++ b/pkg/kube/resourcemapper.go
@@ -7,7 +7,7 @@ import (
 
 // ResourceMap are resources from where changes are going to be detected
 var ResourceMap = map[string]runtime.Object{
-	"configMaps": &v1.ConfigMap{},
+	"configmaps": &v1.ConfigMap{},
 	"secrets":    &v1.Secret{},
-	"namespaces":    &v1.Namespace{},
+	"namespaces": &v1.Namespace{},
 }


### PR DESCRIPTION
This addresses issue #1060 by fixing the constant used in ResourceMap for configmaps.