### PR TITLE
feat: cronjobs/finalizers update permission

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/role.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/role.yaml
@@ -77,6 +77,12 @@ rules:
   - apiGroups:
       - "batch"
     resources:
+      - cronjobs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - "batch"
+    resources:
       - jobs
     verbs:
       - create


### PR DESCRIPTION
Resolves #1083

In a cluster with [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller enabled, Reloader unable to create Job from CronJob template as missing `batch cronjobs/finalizers update` permission.

Have tested this by adding an additional role binding to the reloader service account.

Before:
```
time="2026-01-09T16:42:54Z" level=error msg="Update for 'test-cronjob' of type 'CronJob' in namespace 'example' failed with error jobs.batch \"test-cronjob-shkqt\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"
time="2026-01-09T16:42:54Z" level=error msg="Rolling upgrade for 'test-secret' failed with error = jobs.batch \"test-cronjob-shkqt\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"
```

After:
```
time="2026-01-12T08:32:22Z" level=info msg="Changes detected in 'test-secret' of type 'SECRET' in namespace 'example'; updated 'test-cronjob' of type 'CronJob' in namespace 'example'"
```