### PR TITLE
fix: Normalize resources-to-ignore values to match ResourceMap keys

### DIFF
--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -123,7 +123,12 @@ func GetIgnoredResourcesList() (List, error) {
 		return nil, errors.New("'resources-to-ignore' only accepts 'configMaps' or 'secrets', not both")
 	}
 
-	return ignoredResourcesList, nil
+	normalizedList := make(List, len(ignoredResourcesList))
+	for i, v := range ignoredResourcesList {
+		normalizedList[i] = strings.ToLower(v)
+	}
+
+	return normalizedList, nil
 }
 
 func GetIgnoredWorkloadTypesList() (List, error) {

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -136,6 +136,81 @@ func TestGetIgnoredWorkloadTypesList(t *testing.T) {
 	}
 }
 
+func TestGetIgnoredResourcesList(t *testing.T) {
+	originalResources := options.ResourcesToIgnore
+	defer func() {
+		options.ResourcesToIgnore = originalResources
+	}()
+
+	tests := []struct {
+		name        string
+		resources   []string
+		expectError bool
+		expected    []string
+	}{
+		{
+			name:        "configMaps normalized to lowercase",
+			resources:   []string{"configMaps"},
+			expectError: false,
+			expected:    []string{"configmaps"},
+		},
+		{
+			name:        "secrets stays lowercase",
+			resources:   []string{"secrets"},
+			expectError: false,
+			expected:    []string{"secrets"},
+		},
+		{
+			name:        "Empty list",
+			resources:   []string{},
+			expectError: false,
+			expected:    []string{},
+		},
+		{
+			name:        "Invalid resource",
+			resources:   []string{"invalid"},
+			expectError: true,
+			expected:    nil,
+		},
+		{
+			name:        "Both resources - error",
+			resources:   []string{"configMaps", "secrets"},
+			expectError: true,
+			expected:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options.ResourcesToIgnore = tt.resources
+
+			result, err := GetIgnoredResourcesList()
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if !tt.expectError {
+				if len(result) != len(tt.expected) {
+					t.Errorf("Expected %v, got %v", tt.expected, result)
+					return
+				}
+
+				for i, expected := range tt.expected {
+					if i >= len(result) || result[i] != expected {
+						t.Errorf("Expected %v, got %v", tt.expected, result)
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestListContains(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Fixes case mismatch between `--resources-to-ignore=configMaps` (camelCase) and `ResourceMap` keys (`configmaps` lowercase)
- Adds unit tests for `GetIgnoredResourcesList` function

## Problem
When using `ignoreConfigMaps: true` in Helm values, the generated `--resources-to-ignore=configMaps` flag was not working because `ResourceMap` uses lowercase keys. This caused permission errors when RBAC was configured without configmaps access.

## Solution
Normalize the ignored resources list to lowercase in `GetIgnoredResourcesList()` to match `ResourceMap` keys.

Fixes #1068