### PR TITLE
Handle CronJob upgrade via active Job Pod deletion

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -96,6 +96,14 @@ rules:
       - list
       - get
 {{- end}}
+{{- if and .Values.reloader.ignoreCronJobs .Values.reloader.ignoreJobs }}{{- else }}
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - deletecollection
+{{- end }}
 {{- if .Values.reloader.enableHA }}
   - apiGroups:
       - "coordination.k8s.io"

--- a/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/clusterrole.yaml
@@ -96,7 +96,7 @@ rules:
       - list
       - get
 {{- end}}
-{{- if and .Values.reloader.ignoreCronJobs .Values.reloader.ignoreJobs }}{{- else }}
+{{- if .Values.reloader.ignoreCronJobs }}{{- else }}
   - apiGroups:
       - ""
     resources:

--- a/deployments/kubernetes/manifests/clusterrole.yaml
+++ b/deployments/kubernetes/manifests/clusterrole.yaml
@@ -54,6 +54,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+    verbs:
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
       - events
     verbs:
       - create

--- a/internal/pkg/handler/upgrade.go
+++ b/internal/pkg/handler/upgrade.go
@@ -52,7 +52,7 @@ func GetDeploymentRollingUpgradeFuncs() callbacks.RollingUpgradeFuncs {
 	}
 }
 
-// GetDeploymentRollingUpgradeFuncs returns all callback funcs for a cronjob
+// GetCronJobCreateJobFuncs returns all callback funcs for a cronjob
 func GetCronJobCreateJobFuncs() callbacks.RollingUpgradeFuncs {
 	return callbacks.RollingUpgradeFuncs{
 		ItemFunc:           callbacks.GetCronJobItem,
@@ -61,7 +61,7 @@ func GetCronJobCreateJobFuncs() callbacks.RollingUpgradeFuncs {
 		PodAnnotationsFunc: callbacks.GetCronJobPodAnnotations,
 		ContainersFunc:     callbacks.GetCronJobContainers,
 		InitContainersFunc: callbacks.GetCronJobInitContainers,
-		UpdateFunc:         callbacks.CreateJobFromCronjob,
+		UpdateFunc:         callbacks.RestartRunningCronjobPods,
 		PatchFunc:          callbacks.PatchCronJob,
 		PatchTemplatesFunc: func() callbacks.PatchTemplates { return callbacks.PatchTemplates{} },
 		VolumesFunc:        callbacks.GetCronJobVolumes,
@@ -70,7 +70,7 @@ func GetCronJobCreateJobFuncs() callbacks.RollingUpgradeFuncs {
 	}
 }
 
-// GetDeploymentRollingUpgradeFuncs returns all callback funcs for a cronjob
+// GetJobCreateJobFuncs returns all callback funcs for a cronjob
 func GetJobCreateJobFuncs() callbacks.RollingUpgradeFuncs {
 	return callbacks.RollingUpgradeFuncs{
 		ItemFunc:           callbacks.GetJobItem,

--- a/internal/pkg/testutil/kube.go
+++ b/internal/pkg/testutil/kube.go
@@ -41,7 +41,7 @@ var (
 	ConfigmapResourceType = "configMaps"
 	// SecretResourceType is a resource type which controller watches for changes
 	SecretResourceType = "secrets"
-	// SecretproviderclasspodstatusResourceType is a resource type which controller watches for changes
+	// SecretProviderClassPodStatusResourceType is a resource type which controller watches for changes
 	SecretProviderClassPodStatusResourceType = "secretproviderclasspodstatuses"
 )
 
@@ -886,7 +886,7 @@ func CreateDeployment(client kubernetes.Interface, deploymentName string, namesp
 	return deployment, err
 }
 
-// CreateDeployment creates a deployment in given namespace and returns the Deployment
+// CreateDeploymentWithAnnotations creates a deployment in given namespace and returns the Deployment
 func CreateDeploymentWithAnnotations(client kubernetes.Interface, deploymentName string, namespace string, additionalAnnotations map[string]string, volumeMount bool) (*appsv1.Deployment, error) {
 	logrus.Infof("Creating Deployment")
 	deploymentClient := client.AppsV1().Deployments(namespace)
@@ -1088,7 +1088,7 @@ func DeleteCronJob(client kubernetes.Interface, namespace string, cronJobName st
 	return cronJobError
 }
 
-// Deleteob deletes a job in given namespace and returns the error if any
+// DeleteJob deletes a job in given namespace and returns the error if any
 func DeleteJob(client kubernetes.Interface, namespace string, jobName string) error {
 	logrus.Infof("Deleting Job %s", jobName)
 	jobError := client.BatchV1().Jobs(namespace).Delete(context.TODO(), jobName, metav1.DeleteOptions{})

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -25,7 +25,7 @@ type Clients struct {
 var (
 	// IsOpenshift is true if environment is Openshift, it is false if environment is Kubernetes
 	IsOpenshift = isOpenshift()
-	// IsCSIEnabled is true if environment has CSI provider installed, otherwise false
+	// IsCSIInstalled is true if environment has CSI provider installed, otherwise false
 	IsCSIInstalled = isCSIInstalled()
 )
 


### PR DESCRIPTION
Instead of immediately creating new Jobs we will instead delete pods belonging to active Jobs. This will cause the job controller to re-create the pods based on the defined policies.

As such we will not violate the CronJob schedule, suspension and concurrency policies.

Resolves #822