### PR TITLE
Add opt-in patch mode for CronJob reload strategy

### DIFF
--- a/internal/pkg/handler/upgrade_test.go
+++ b/internal/pkg/handler/upgrade_test.go
@@ -5151,3 +5151,59 @@ func TestGetContainerUsingResourceWithArgoRolloutEmptyContainers(t *testing.T) {
 		})
 	}
 }
+
+// TestGetCronJobPatchFuncs tests that the CronJob patch funcs are configured correctly
+func TestGetCronJobPatchFuncs(t *testing.T) {
+	patchFuncs := GetCronJobPatchFuncs()
+
+	assert.True(t, patchFuncs.SupportsPatch, "CronJob patch funcs should support patching")
+	assert.Equal(t, "CronJob", patchFuncs.ResourceType)
+	assert.NotNil(t, patchFuncs.ItemFunc)
+	assert.NotNil(t, patchFuncs.ItemsFunc)
+	assert.NotNil(t, patchFuncs.AnnotationsFunc)
+	assert.NotNil(t, patchFuncs.PodAnnotationsFunc)
+	assert.NotNil(t, patchFuncs.ContainersFunc)
+	assert.NotNil(t, patchFuncs.InitContainersFunc)
+	assert.NotNil(t, patchFuncs.UpdateFunc)
+	assert.NotNil(t, patchFuncs.PatchFunc)
+	assert.NotNil(t, patchFuncs.PatchTemplatesFunc)
+	assert.NotNil(t, patchFuncs.VolumesFunc)
+
+	// Verify patch templates are correct for CronJob
+	templates := patchFuncs.PatchTemplatesFunc()
+	assert.NotEmpty(t, templates.AnnotationTemplate)
+	assert.Contains(t, templates.AnnotationTemplate, "jobTemplate")
+	assert.NotEmpty(t, templates.EnvVarTemplate)
+	assert.Contains(t, templates.EnvVarTemplate, "jobTemplate")
+	assert.NotEmpty(t, templates.DeleteEnvVarTemplate)
+	assert.Contains(t, templates.DeleteEnvVarTemplate, "jobTemplate")
+}
+
+// TestGetCronJobCreateJobFuncs tests that the default CronJob funcs are configured correctly
+func TestGetCronJobCreateJobFuncs(t *testing.T) {
+	createJobFuncs := GetCronJobCreateJobFuncs()
+
+	assert.False(t, createJobFuncs.SupportsPatch, "CronJob create-job funcs should not support patching")
+	assert.Equal(t, "CronJob", createJobFuncs.ResourceType)
+	assert.NotNil(t, createJobFuncs.ItemFunc)
+	assert.NotNil(t, createJobFuncs.ItemsFunc)
+	assert.NotNil(t, createJobFuncs.AnnotationsFunc)
+	assert.NotNil(t, createJobFuncs.PodAnnotationsFunc)
+	assert.NotNil(t, createJobFuncs.ContainersFunc)
+	assert.NotNil(t, createJobFuncs.InitContainersFunc)
+	assert.NotNil(t, createJobFuncs.UpdateFunc)
+	assert.NotNil(t, createJobFuncs.PatchFunc)
+	assert.NotNil(t, createJobFuncs.PatchTemplatesFunc)
+	assert.NotNil(t, createJobFuncs.VolumesFunc)
+
+	// Verify patch templates are empty for default CronJob funcs (since it doesn't support patching)
+	templates := createJobFuncs.PatchTemplatesFunc()
+	assert.Empty(t, templates.AnnotationTemplate)
+	assert.Empty(t, templates.EnvVarTemplate)
+	assert.Empty(t, templates.DeleteEnvVarTemplate)
+}
+
+// TestCronJobReloadStrategyAnnotation tests that the CronJobReloadStrategyAnnotation constant is set correctly
+func TestCronJobReloadStrategyAnnotation(t *testing.T) {
+	assert.Equal(t, "reloader.stakater.com/cronjob-reload-strategy", options.CronJobReloadStrategyAnnotation)
+}

--- a/internal/pkg/options/flags.go
+++ b/internal/pkg/options/flags.go
@@ -47,6 +47,8 @@ var (
 	SearchMatchAnnotation = "reloader.stakater.com/match"
 	// RolloutStrategyAnnotation is an annotation to define rollout update strategy
 	RolloutStrategyAnnotation = "reloader.stakater.com/rollout-strategy"
+	// CronJobReloadStrategyAnnotation is an annotation to define cronjob reload strategy (default: "immediate-job", opt-in: "patch")
+	CronJobReloadStrategyAnnotation = "reloader.stakater.com/cronjob-reload-strategy"
 	// PauseDeploymentAnnotation is an annotation to define the time period to pause a deployment after
 	// a configmap/secret change has been detected. Valid values are described here: https://pkg.go.dev/time#ParseDuration
 	// only positive values are allowed


### PR DESCRIPTION
## Summary          
   - Add new annotation `reloader.stakater.com/cronjob-reload-strategy: patch` that allows CronJobs to use patch mode instead of creating immediate Jobs                          
   - When enabled, patches the CronJob template and recreates any running Jobs owned by the CronJob                                                                               
   - Default behavior (creating immediate Job) remains unchanged for backward compatibility                                                                                       
                                                                                                                                                                                  
   ## Problem                                                                                                                                                                     
   When a ConfigMap/Secret is updated, Reloader creates an immediate Job from the CronJob template. This causes:                                                                  
   1. Out-of-schedule job execution                                                                                                                                               
   2. "Orphan" jobs not tracked by CronJob controller's history limits                                                                                                            
   3. Bypasses CronJob's `concurrencyPolicy`                                                                                                                                      
                                                                                                                                                                                  
   ## Solution                                                                                                                                                                    
   Add an opt-in `patch` strategy that:                                                                                                                                           
   1. Patches the CronJob template (so future scheduled runs get new config)                                                                                                      
   2. Finds and recreates any running Jobs owned by the CronJob                                                                                                                   
   3. Does NOT create an extra immediate Job                                                                                                                                      
                                                                                                                                                                                  
   ## Usage                                                                                                                                                                       
   ```yaml                                                                                                                                                                        
   apiVersion: batch/v1                                                                                                                                                           
   kind: CronJob                                                                                                                                                                  
   metadata:                                                                                                                                                                      
     name: my-cronjob                                                                                                                                                             
     annotations:                                                                                                                                                                 
       reloader.stakater.com/auto: "true"                                                                                                                                         
       reloader.stakater.com/cronjob-reload-strategy: "patch"                                                                                                                     
   ```                                                                                                                                                                            
                                                                                                                                                                                  
   ## Test plan                                                                                                                                                                   
   - [x] Unit tests for new callback functions (`PatchCronJob`, `RecreateRunningJobsForCronJob`, `UpdateCronJobWithRunningJobs`)                                                  
   - [x] Unit tests for CronJob patch templates                                                                                                                                   
   - [x] Unit tests for `GetCronJobPatchFuncs` and `GetCronJobCreateJobFuncs`                                                                                                     
   - [ ] Manual test: Deploy CronJob WITHOUT annotation, update ConfigMap → verify immediate Job is created                                                                       
   - [ ] Manual test: Deploy CronJob WITH `patch` annotation, update ConfigMap → verify CronJob template is patched, NO immediate Job created     