### PR TITLE
Bump Helm chart to 2.2.10-alpha (appVersion v1.4.14-alpha)

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 2.2.9
-appVersion: v1.4.14
+version: 2.2.10-alpha
+appVersion: v1.4.14-alpha
 keywords:
   - Reloader
   - kubernetes

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -19,7 +19,7 @@ fullnameOverride: ""
 image:
   name: stakater/reloader
   repository: ghcr.io/stakater/reloader
-  tag: v1.4.14
+  tag: v1.4.14-alpha
   # digest: sha256:1234567
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bump Helm chart version to 2.2.10-alpha and appVersion to v1.4.14-alpha.