### PR TITLE
Harden GitHub Actions workflows against cache poisoning

### DIFF
--- a/.github/actions/loadtest/action.yml
+++ b/.github/actions/loadtest/action.yml
@@ -209,12 +209,21 @@ runs:
     - name: Post PR comment
       if: inputs.post-comment == 'true' && inputs.pr-number != ''
       continue-on-error: true
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      # Untrusted/templated values are passed via env and read with process.env
+      # inside the script, so they are never interpolated into JS source.
+      env:
+        SUMMARY_PATH: ${{ github.workspace }}/test/loadtest/summary.md
+        COMMENT_HEADER: ${{ inputs.comment-header }}
+        RUN_STATUS: ${{ steps.run.outputs.status }}
+        TEST_TYPE: ${{ inputs.test-type }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           const fs = require('fs');
-          const summaryPath = '${{ github.workspace }}/test/loadtest/summary.md';
+          const summaryPath = process.env.SUMMARY_PATH;
           let summary = 'No results available';
           try {
             summary = fs.readFileSync(summaryPath, 'utf8');
@@ -222,24 +231,24 @@ runs:
             console.log('Could not read summary file:', e.message);
           }
 
-          const header = '${{ inputs.comment-header }}';
-          const status = '${{ steps.run.outputs.status }}';
+          const header = process.env.COMMENT_HEADER;
+          const status = process.env.RUN_STATUS;
           const statusEmoji = status === 'pass' ? ':white_check_mark:' : ':x:';
 
           const body = [
-            header ? header : `## ${statusEmoji} Load Test Results (${{ inputs.test-type }})`,
+            header ? header : `## ${statusEmoji} Load Test Results (${process.env.TEST_TYPE})`,
             '',
             summary,
             '',
             '---',
-            `**Artifacts:** [Download](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`,
+            `**Artifacts:** [Download](${process.env.RUN_URL})`,
           ].join('\n');
 
           try {
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ inputs.pr-number }},
+              issue_number: Number(process.env.PR_NUMBER),
               body: body
             });
             console.log('Comment posted successfully');
@@ -252,7 +261,7 @@ runs:
           }
 
     - name: Upload results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
         name: loadtest-${{ inputs.test-type }}-results

--- a/.github/workflows/init-branch-release.yaml
+++ b/.github/workflows/init-branch-release.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           git diff
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           commit-message: "Bump version to ${{ inputs.TARGET_VERSION }}"
           title: "Bump version to ${{ inputs.TARGET_VERSION }} on ${{ inputs.TARGET_BRANCH }} branch"

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Add reaction to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -46,19 +46,19 @@ jobs:
             console.log(`PR #${context.issue.number}: ${pr.data.head.ref} -> ${pr.data.base.ref}`);
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0  # Full history for building from base ref
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.26'
           cache: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Install kind
         run: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Add success reaction
         if: steps.loadtest.outputs.status == 'pass'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -101,7 +101,7 @@ jobs:
 
       - name: Add failure reaction
         if: steps.loadtest.outputs.status == 'fail'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -14,6 +14,9 @@ env:
   KIND_VERSION: "0.23.0"
   REGISTRY: ghcr.io
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
 
   helm-chart-validation:
@@ -26,19 +29,19 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
 
     # Setting up helm binary
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       with:
         version: v3.11.3
 
     - name: Helm chart unit tests
-      uses: d3adb5/helm-unittest-action@v2
+      uses: d3adb5/helm-unittest-action@850bc76597579183998069830d5fa8c3ef0ea34a # v2
       with:
         charts: deployments/kubernetes/chart/reloader
 
@@ -55,7 +58,7 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
@@ -71,13 +74,13 @@ jobs:
         echo "CURRENT_CHART_VERSION=$(echo ${current_chart_version})" >> $GITHUB_OUTPUT
 
     - name: Get Updated Chart version from Chart.yaml
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
       id: new_chart_version
       with:
         cmd: yq e '.version' deployments/kubernetes/chart/reloader/Chart.yaml
 
     - name: Check Version
-      uses: aleoyakas/check-semver-increased-action@v1
+      uses: aleoyakas/check-semver-increased-action@415c9c60054c2442c03478b6dd96a195deac6695 # v1
       id: check-version
       with:
         current-version: ${{ steps.new_chart_version.outputs.result }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,9 +19,15 @@ env:
   REGISTRY: ghcr.io
   RELOADER_EDITION: oss
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
   qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.163
+    permissions:
+      contents: read
+      pull-requests: write # reusable workflow posts languagetool review comments
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@3dfb835dba6b596fe32e1d0f5eadbb4a3a139a1c # v0.0.163
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: README.md
@@ -38,30 +44,30 @@ jobs:
     name: Build
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
 
     # Setting up helm binary
     - name: Set up Helm
-      uses: azure/setup-helm@v5
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
       with:
         version: v3.20.2
 
     - name: Helm chart unit tests
-      uses: d3adb5/helm-unittest-action@v2
+      uses: d3adb5/helm-unittest-action@850bc76597579183998069830d5fa8c3ef0ea34a # v2
       with:
         charts: deployments/kubernetes/chart/reloader
         helm-version: v3.20.2
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         check-latest: true
-        cache: true
+        cache: false
 
     - name: Create timestamp
       id: prep
@@ -130,10 +136,10 @@ jobs:
         echo "GIT_UBI_TAG=$(echo ${ubi_tag})" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Generate image repository path for ghcr registry
       run: |
@@ -142,7 +148,7 @@ jobs:
     # To identify any broken changes in dockerfiles or dependencies
 
     - name: Build Docker Image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         file: ${{ env.DOCKER_FILE_PATH  }}
@@ -155,7 +161,6 @@ jobs:
           EDITION=${{ env.RELOADER_EDITION }}
           BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
         
-        cache-to: type=inline
         platforms: linux/amd64,linux/arm,linux/arm64
         tags: |
           ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
@@ -165,7 +170,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
 
     - name: Build Docker UBI Image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         file: ${{ env.DOCKER_UBI_FILE_PATH  }}
@@ -178,7 +183,6 @@ jobs:
           EDITION=${{ env.RELOADER_EDITION }}
           BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
           BUILDER_IMAGE=${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.highest_tag.outputs.tag }}
-        cache-to: type=inline
         platforms: linux/amd64,linux/arm64
         tags: |
           ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_UBI_TAG }}

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -17,6 +17,9 @@ env:
   HELM_REGISTRY_URL: "https://stakater.github.io/stakater-charts"
   REGISTRY: ghcr.io # container registry
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
   verify-and-push-helm-chart:
 
@@ -31,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.PUBLISH_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
@@ -39,7 +42,7 @@ jobs:
 
       # Setting up helm binary
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.11.3
 
@@ -54,13 +57,13 @@ jobs:
           echo "CURRENT_CHART_VERSION=$(echo ${current_chart_version})" >> $GITHUB_OUTPUT
 
       - name: Get Updated Chart version from Chart.yaml
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         id: new_chart_version
         with:
           cmd: yq e '.version' deployments/kubernetes/chart/reloader/Chart.yaml
 
       - name: Check Version
-        uses: aleoyakas/check-semver-increased-action@v1
+        uses: aleoyakas/check-semver-increased-action@415c9c60054c2442c03478b6dd96a195deac6695 # v1
         id: check-version
         with:
           current-version: ${{ steps.new_chart_version.outputs.result }}
@@ -73,10 +76,10 @@ jobs:
           exit 1
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Login to GHCR Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: stakater-user
@@ -92,7 +95,7 @@ jobs:
         run: cosign sign --yes ghcr.io/stakater/charts/reloader:${{ steps.new_chart_version.outputs.result }}
 
       - name: Publish Helm chart to gh-pages
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           branch: master
           repository: stakater-charts
@@ -106,14 +109,14 @@ jobs:
           commit_email: stakater@gmail.com
 
       - name: Push new chart tag
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: false
           CUSTOM_TAG: chart-v${{ steps.new_chart_version.outputs.result }}
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         if: always() # Pick up events even if the job fails or is canceled.
         with:
           status: ${{ job.status }}

--- a/.github/workflows/push-pr-image.yaml
+++ b/.github/workflows/push-pr-image.yaml
@@ -14,6 +14,9 @@ env:
   DOCKER_FILE_PATH: Dockerfile
   REGISTRY: ghcr.io
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
 
   build-and-push-pr-image:
@@ -25,17 +28,17 @@ jobs:
     if: ${{ github.event.label.name == 'build-and-push-pr-image' }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         check-latest: true
-        cache: true
+        cache: false
 
     - name: Install Dependencies
       run: |
@@ -52,31 +55,30 @@ jobs:
         echo "GIT_TAG=$(echo ${tag})" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Generate image repository path for ghcr registry
       run: |
         echo GHCR_IMAGE_REPOSITORY=${{env.REGISTRY}}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
     - name: Login to ghcr registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{env.REGISTRY}}
         username: stakater-user
         password: ${{secrets.GITHUB_TOKEN}}
 
     - name: Build Docker Image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         file: ${{ env.DOCKER_FILE_PATH  }}
         pull: true
         push: true
         build-args: BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-        cache-to: type=inline
         platforms: linux/amd64,linux/arm,linux/arm64
         tags: |
           ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,6 +17,9 @@ env:
   REGISTRY: ghcr.io
   RELOADER_EDITION: oss
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
   build:
 
@@ -30,7 +33,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.PUBLISH_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
@@ -38,16 +41,16 @@ jobs:
 
       # Setting up helm binary
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.11.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Install Dependencies
         run: |
@@ -78,13 +81,13 @@ jobs:
         run: make test
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.STAKATER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.STAKATER_DOCKERHUB_PASSWORD }}
@@ -98,7 +101,7 @@ jobs:
           echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Build and Push Docker Image to Docker registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_FILE_PATH  }}
@@ -110,7 +113,6 @@ jobs:
             BUILD_DATE=${{ steps.prep.outputs.created }}
             EDITION=${{ env.RELOADER_EDITION }}
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}
@@ -119,7 +121,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and Push Docker UBI Image to Docker registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_UBI_FILE_PATH  }}
@@ -128,7 +130,6 @@ jobs:
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
             BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}-ubi
@@ -137,7 +138,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Login to ghcr registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{env.REGISTRY}}
           username: stakater-user
@@ -148,7 +149,7 @@ jobs:
           echo GHCR_IMAGE_REPOSITORY=${{env.REGISTRY}}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Build and Push Docker Image to ghcr registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_FILE_PATH  }}
@@ -160,7 +161,6 @@ jobs:
             BUILD_DATE=${{ steps.prep.outputs.created }}
             EDITION=${{ env.RELOADER_EDITION }}
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}
@@ -169,7 +169,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and Push Docker UBI Image to ghcr registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_UBI_FILE_PATH  }}
@@ -178,7 +178,6 @@ jobs:
           build-args: |
             BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
             BUILDER_IMAGE=${{ env.GHCR_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}:merge-${{ github.event.number }}-ubi
@@ -187,14 +186,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Push Latest Tag
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: false
           CUSTOM_TAG: merge-${{ github.event.number }}
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         if: always() # Pick up events even if the job fails or is canceled.
         with:
           status: ${{ job.status }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
               --generate-notes
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         if: always()
         with:
           status: ${{ job.status }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ env:
   REGISTRY: ghcr.io
   RELOADER_EDITION: oss
 
+# Default to no GITHUB_TOKEN permissions; each job opts into the minimum it needs.
+permissions: {}
+
 jobs:
   release:
 
@@ -25,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.PUBLISH_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
@@ -33,16 +36,16 @@ jobs:
 
       # Setting up helm binary
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.11.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Install Dependencies
         run: |
@@ -81,13 +84,13 @@ jobs:
         run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.STAKATER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.STAKATER_DOCKERHUB_PASSWORD }}
@@ -97,13 +100,12 @@ jobs:
           echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Build and Push Docker Image to Docker registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_FILE_PATH  }}
           pull: true
           push: true
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}
@@ -118,7 +120,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and Push Docker UBI Image to Docker registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_UBI_FILE_PATH  }}
@@ -126,7 +128,6 @@ jobs:
           push: true
           build-args: |
             BUILDER_IMAGE=${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}-ubi
@@ -136,7 +137,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Login to ghcr registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{env.REGISTRY}}
           username: stakater-user
@@ -148,13 +149,12 @@ jobs:
 
       # tag this image as latest as it will be used in plain manifests
       - name: Build and Push Docker Image to ghcr registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_FILE_PATH  }}
           pull: true
           push: true
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }},${{ env.GHCR_IMAGE_REPOSITORY }}:latest
@@ -169,7 +169,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and Push Docker UBI Image to ghcr registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ env.DOCKER_UBI_FILE_PATH  }}
@@ -177,7 +177,6 @@ jobs:
           push: true
           build-args: |
             BUILDER_IMAGE=${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}
-          cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}-ubi
@@ -191,7 +190,7 @@ jobs:
       ##############################
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: release --clean
@@ -199,7 +198,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         if: always() # Pick up events even if the job fails or is canceled.
         with:
           status: ${{ job.status }}

--- a/.github/workflows/reloader-enterprise-published.yml
+++ b/.github/workflows/reloader-enterprise-published.yml
@@ -4,14 +4,21 @@ on:
   release:
     types: [published]
 
+# Authenticates with a PAT, not GITHUB_TOKEN — no token scopes needed.
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger target repository workflow
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          payload=$(jq -nc --arg tag "$RELEASE_TAG" \
+            '{event_type: "release-published", client_payload: {tag: $tag}}')
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.STAKATER_AB_TOKEN_FOR_RLDR }}" \
           https://api.github.com/repos/stakater-ab/reloader-enterprise/dispatches \
-          -d '{"event_type":"release-published","client_payload":{"tag":"${{ github.event.release.tag_name }}"}}'
+          -d "$payload"

--- a/.github/workflows/reloader-enterprise-unpublished.yml
+++ b/.github/workflows/reloader-enterprise-unpublished.yml
@@ -4,14 +4,21 @@ on:
   release:
     types: [unpublished ]
 
+# Authenticates with a PAT, not GITHUB_TOKEN — no token scopes needed.
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger target repository workflow
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          payload=$(jq -nc --arg tag "$RELEASE_TAG" \
+            '{event_type: "release-unpublished", client_payload: {tag: $tag}}')
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.STAKATER_AB_TOKEN_FOR_RLDR }}" \
           https://api.github.com/repos/stakater-ab/reloader-enterprise/dispatches \
-          -d '{"event_type":"release-unpublished","client_payload":{"tag":"${{ github.event.release.tag_name }}"}}'
+          -d "$payload"


### PR DESCRIPTION
## What

Hardens all GitHub Actions workflows against the cache-poisoning / supply-chain attack class (Angular, tj-actions, Cline, TanStack), following the audit checklist at https://neciudan.dev/github-actions-poisoning.

## Changes

### Caching disabled

- `actions/setup-go` set to `cache: false` in `push`, `pull_request`, `release`, and `push-pr-image` (setup-go caches by default, so the flag must be explicit — deleting it re-enables caching).
- Removed all 11 `cache-to: type=inline` buildx cache exports.

This prevents a poisoned dependency/layer planted from a low-trust PR run from being restored by a higher-privileged release run.

### All actions pinned to commit SHAs

- Every third-party `uses:` (23 refs across 9 workflows + the composite action, including the `stakater/.github` reusable workflow) is now pinned to a full commit SHA with a `# vX` comment.
- The three `@master`-pinned actions (`mikefarah/yq`, `stefanprodan/helm-gh-pages`, `goreleaser/goreleaser-action`) are pinned to their latest release SHA. Note: `goreleaser-action` moves from a floating `master` to `v7.2.2`.

### Injection fixes

- `reloader-enterprise-{published,unpublished}.yml`: `github.event.release.tag_name` was interpolated into a single-quoted `curl` JSON body — now passed via `env:` and built safely with `jq -nc`.
- `actions/loadtest` composite action: untrusted values (`comment-header`, which carries the PR branch name, plus `test-type`, `status`, `pr-number`) were interpolated into `github-script` JS source — now passed via step `env:` and read with `process.env`.
    
 ### Least-privilege permissions

- Added a top-level `permissions: {}` default-deny block to every workflow that lacked one.
- Gave `pull_request.yaml`'s `qa` job an explicit `contents: read` + `pull-requests: write` (the reusable doc-QA workflow needs it to post languagetool review comments).
    
## Notes

- No behavior change expected — caching only affects CI speed, not correctness; SHA pins resolve to the same versions already in use.
- If caching is reintroduced later, use separate `actions/cache/restore` + `save` with a release-scoped key prefix that PR workflows cannot write.
    