### PR TITLE
fix: reflect --namespaces-to-ignore in startup namespace-scope log

### DIFF
--- a/internal/pkg/cmd/reloader.go
+++ b/internal/pkg/cmd/reloader.go
@@ -102,6 +102,20 @@ func getHAEnvs() (string, string) {
 	return podName, podNamespace
 }
 
+// namespaceWatchScopeMessage returns the startup log message describing the
+// namespace scope Reloader will watch when KUBERNETES_NAMESPACE is unset
+// (global mode). It reflects --namespaces-to-ignore so the log is not
+// misleading when namespace filtering is configured.
+func namespaceWatchScopeMessage(ignoredNamespaces []string) string {
+	if len(ignoredNamespaces) > 0 {
+		return fmt.Sprintf(
+			"KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces except: %s.",
+			strings.Join(ignoredNamespaces, ", "),
+		)
+	}
+	return "KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces."
+}
+
 func startReloader(cmd *cobra.Command, args []string) {
 	common.GetCommandLineOptions()
 	err := configureLogging(options.LogFormat, options.LogLevel)
@@ -115,7 +129,6 @@ func startReloader(cmd *cobra.Command, args []string) {
 	if len(currentNamespace) == 0 {
 		currentNamespace = v1.NamespaceAll
 		isGlobal = true
-		logrus.Warnf("KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces.")
 	}
 
 	// create the clientset
@@ -130,6 +143,9 @@ func startReloader(cmd *cobra.Command, args []string) {
 	}
 
 	ignoredNamespacesList := options.NamespacesToIgnore
+	if isGlobal {
+		logrus.Warn(namespaceWatchScopeMessage(ignoredNamespacesList))
+	}
 	namespaceLabelSelector := ""
 
 	if isGlobal {

--- a/internal/pkg/cmd/reloader_test.go
+++ b/internal/pkg/cmd/reloader_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import "testing"
+
+func TestNamespaceWatchScopeMessage(t *testing.T) {
+	tests := []struct {
+		name              string
+		ignoredNamespaces []string
+		want              string
+	}{
+		{
+			name:              "no ignored namespaces - all namespaces",
+			ignoredNamespaces: nil,
+			want:              "KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces.",
+		},
+		{
+			name:              "empty ignored namespaces - all namespaces",
+			ignoredNamespaces: []string{},
+			want:              "KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces.",
+		},
+		{
+			name:              "single ignored namespace",
+			ignoredNamespaces: []string{"kube-system"},
+			want:              "KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces except: kube-system.",
+		},
+		{
+			name:              "multiple ignored namespaces",
+			ignoredNamespaces: []string{"kube-system", "kube-public"},
+			want:              "KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces except: kube-system, kube-public.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := namespaceWatchScopeMessage(tt.ignoredNamespaces); got != tt.want {
+				t.Errorf("namespaceWatchScopeMessage(%v) = %q, want %q", tt.ignoredNamespaces, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem

When `KUBERNETES_NAMESPACE` is unset (global mode), Reloader logs at startup:

```
level=warning msg="KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces."
```

This message is printed unconditionally, even when `--namespaces-to-ignore` is
configured, so the log claims it watches *all* namespaces while namespace
filtering is actually active. Reported in #1131 (confirmed on v1.4.2 and v1.4.14).

### Root cause

`internal/pkg/cmd/reloader.go` logged the "all namespaces" message inside the
`len(currentNamespace) == 0` block (formerly line 118), **before**
`ignoredNamespacesList := options.NamespacesToIgnore` was resolved (line 132).
The log had no visibility into the ignore list.

### Fix

- Extract the message into a small, testable helper
  `namespaceWatchScopeMessage(ignoredNamespaces []string) string`.
- Move the log to after `ignoredNamespacesList` is resolved (still gated on
  global mode).
- When `--namespaces-to-ignore` is non-empty, the message now reads:
  `KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces except: <ns1>, <ns2>.`
  Otherwise the original message is unchanged.

Minimal diff: 17 insertions, 1 deletion in `reloader.go` plus a new unit test.

### Test / verification

- Added `internal/pkg/cmd/reloader_test.go` (`TestNamespaceWatchScopeMessage`)
  covering nil/empty (all-namespaces) and single/multiple ignored-namespace
  cases. Verified it **fails** against the old behavior and **passes** with the
  fix.
- `go test ./internal/pkg/cmd/...` → ok
- `go vet ./internal/pkg/cmd/`, `go build ./...`, `gofmt -l` → clean

### AI assistance

This change was prepared with AI assistance (Claude Code, Anthropic, Opus 4.x).
A human reviewed the root-cause analysis, the fix, and the test before opening
this PR. The commit carries an `Assisted-by:` trailer.

Closes #1131
