### PR TITLE
Bump Helm chart to 2.2.13 (appVersion v1.4.18)

### DIFF
--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 2.2.12
-appVersion: v1.4.17
+version: 2.2.13
+appVersion: v1.4.18
 keywords:
   - Reloader
   - kubernetes

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -19,7 +19,7 @@ fullnameOverride: ""
 image:
   name: stakater/reloader
   repository: ghcr.io/stakater/reloader
-  tag: v1.4.17
+  tag: v1.4.18
   # digest: sha256:1234567
   pullPolicy: IfNotPresent
 
@@ -135,7 +135,7 @@ reloader:
     labels:
       provider: stakater
       group: com.stakater.platform
-      version: v1.4.14
+      version: v1.4.18
     # Support for extra environment variables.
     env:
       # Open supports Key value pair as environment variables.


### PR DESCRIPTION
Bump Helm chart version to 2.2.13 and appVersion to v1.4.18.