### PR TITLE
Log errors returned when sending webhook alerts

### DIFF
--- a/internal/pkg/alerts/alert.go
+++ b/internal/pkg/alerts/alert.go
@@ -40,16 +40,23 @@ func SendWebhookAlert(msg string) {
 		msg = fmt.Sprintf("%s : %s", alert_additional_info, msg)
 	}
 
+	var errs []error
 	switch AlertSink(alert_sink) {
 	case AlertSinkSlack:
-		sendSlackAlert(webhook_url, webhook_proxy, msg)
+		errs = sendSlackAlert(webhook_url, webhook_proxy, msg)
 	case AlertSinkTeams:
-		sendTeamsAlert(webhook_url, webhook_proxy, msg)
+		errs = sendTeamsAlert(webhook_url, webhook_proxy, msg)
 	case AlertSinkGoogleChat:
-		sendGoogleChatAlert(webhook_url, webhook_proxy, msg)
+		errs = sendGoogleChatAlert(webhook_url, webhook_proxy, msg)
 	default:
 		msg = strings.ReplaceAll(msg, "*", "")
-		sendRawWebhookAlert(webhook_url, webhook_proxy, msg)
+		errs = sendRawWebhookAlert(webhook_url, webhook_proxy, msg)
+	}
+
+	// Previously the errors returned by the send functions were discarded, so a
+	// failing webhook (e.g. Teams) produced no output at all. Surface them. (#949)
+	for _, err := range errs {
+		logrus.Errorf("Error sending alert: %s", err.Error())
 	}
 }
 

--- a/internal/pkg/alerts/alert_test.go
+++ b/internal/pkg/alerts/alert_test.go
@@ -1,0 +1,40 @@
+package alert
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSendWebhookAlert_LogsSendErrors is a regression test for #949: a failing
+// webhook (here, a non-2xx response) previously produced no output at all
+// because the errors returned by the send functions were discarded. They must
+// now be surfaced as error logs.
+func TestSendWebhookAlert_LogsSendErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
+	t.Setenv("ALERT_WEBHOOK_URL", server.URL)
+	t.Setenv("ALERT_SINK", string(AlertSinkTeams))
+
+	SendWebhookAlert("test message")
+
+	var logged bool
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, "Error sending alert") {
+			logged = true
+			break
+		}
+	}
+	assert.True(t, logged, "expected the swallowed webhook error to be logged")
+}


### PR DESCRIPTION
Closes #949.

### Problem

With `ALERT_ON_RELOAD=true` and a webhook sink (e.g. `ALERT_SINK=teams`), a failing webhook produced **no output at all** — not even at `logLevel: trace`. The alert simply didn't arrive and there was nothing to debug.

### Cause

`SendWebhookAlert` calls `sendSlackAlert` / `sendTeamsAlert` / `sendGoogleChatAlert` / `sendRawWebhookAlert`, each of which returns `[]error`, but the return values were discarded. A non-2xx response (or a transport error) was therefore silently swallowed.

### Fix

Capture the returned errors and log each with `logrus.Errorf("Error sending alert: %s", ...)` — exactly as @Felix-Stakater suggested on the issue. A misconfigured or failing webhook now surfaces a clear error log:

```
level=error msg="Error sending alert: error sending msg. status: 500 Internal Server Error"
```

### Tests

Added `TestSendWebhookAlert_LogsSendErrors` (`internal/pkg/alerts/alert_test.go`): stands up an `httptest` server that returns `500`, points a Teams sink at it, and asserts the error is logged (via a `logrus` test hook). It fails without this change and passes with it. `go build ./...`, `gofmt`, and the new test are green.

<sub>Developed with AI assistance (Claude Code); I directed the change and verified build/test locally.</sub>
