### PR TITLE
Offboard waseem.hassan: remove from OWNERS and chart maintainers

### DIFF
--- a/deployments/kubernetes/chart/reloader/OWNERS
+++ b/deployments/kubernetes/chart/reloader/OWNERS
@@ -2,7 +2,6 @@ approvers:
 - faizanahmad055
 - kahootali
 - ahmadiq
-- waseem-h
 - rasheedamir
 - ahsan-storm
 - ahmedwaleedmalik
@@ -10,7 +9,6 @@ reviewers:
 - faizanahmad055
 - kahootali
 - ahmadiq
-- waseem-h
 - rasheedamir
 - ahsan-storm
 - ahmedwaleedmalik

--- a/deployments/kubernetes/templates/chart/Chart.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/Chart.yaml.tmpl
@@ -17,8 +17,6 @@ maintainers:
   email: hello@stakater.com
 - name: rasheedamir
   email: rasheed@aurorasolutions.io
-- name: waseem-h
-  email: waseemhassan@stakater.com
 - name: faizanahmad055
   email: faizan.ahmad55@outlook.com
 - name: kahootali


### PR DESCRIPTION
## Offboarding: Waseem Hassan

Waseem Hassan has left the organization. This PR removes him from the Reloader project's ownership/maintainer metadata as part of offboarding.

- **GitHub user:** `waseem-h`

### Changes
- `deployments/kubernetes/chart/reloader/OWNERS` — removed from `approvers` and `reviewers`
- `deployments/kubernetes/templates/chart/Chart.yaml.tmpl` — removed from `maintainers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)