### PR TITLE
setup for reloader chart 3.0.0-beta.1

### DIFF
--- a/.github/workflows/pull_request-helm.yaml
+++ b/.github/workflows/pull_request-helm.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: Get version for chart from helm repo
       id: chart_eval
       run: |
-        current_chart_version=$(helm search repo stakater/reloader-v2 | tail -n 1 | awk '{print $2}')
+        current_chart_version=$(helm search repo stakater/reloader --devel | tail -n 1 | awk '{print $2}')
         echo "CURRENT_CHART_VERSION=$(echo ${current_chart_version})" >> $GITHUB_OUTPUT
 
     - name: Get Updated Chart version from Chart.yaml
@@ -82,10 +82,8 @@ jobs:
       with:
         cmd: yq e '.version' deployments/kubernetes/chart/reloader/Chart.yaml
 
-    # Skip the version-increase gate on first publish, when no reloader-v2
-    # chart exists yet in the repo (CURRENT_CHART_VERSION is empty).
+    # --devel above includes prereleases so beta bumps are still gated.
     - name: Check Version
-      if: steps.chart_eval.outputs.CURRENT_CHART_VERSION != ''
       uses: aleoyakas/check-semver-increased-action@415c9c60054c2442c03478b6dd96a195deac6695 # v1
       id: check-version
       with:
@@ -93,7 +91,7 @@ jobs:
         previous-version: ${{ steps.chart_eval.outputs.CURRENT_CHART_VERSION }}
 
     - name: Fail if Helm Chart version isnt updated
-      if: steps.chart_eval.outputs.CURRENT_CHART_VERSION != '' && steps.check-version.outputs.is-version-increased != 'true'
+      if: steps.check-version.outputs.is-version-increased != 'true'
       run: |
         echo "Helm Chart Version wasnt updated"
         exit 1

--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Get version for chart from helm repo
         id: chart_eval
         run: |
-          current_chart_version=$(helm search repo stakater/reloader-v2 | tail -n 1 | awk '{print $2}')
+          current_chart_version=$(helm search repo stakater/reloader --devel | tail -n 1 | awk '{print $2}')
           echo "CURRENT_CHART_VERSION=$(echo ${current_chart_version})" >> $GITHUB_OUTPUT
 
       - name: Get Updated Chart version from Chart.yaml
@@ -63,10 +63,8 @@ jobs:
         with:
           cmd: yq e '.version' deployments/kubernetes/chart/reloader/Chart.yaml
 
-      # Skip the version-increase gate on first publish, when no reloader-v2
-      # chart exists yet in the repo (CURRENT_CHART_VERSION is empty).
+      # --devel above includes prereleases so beta bumps are still gated.
       - name: Check Version
-        if: steps.chart_eval.outputs.CURRENT_CHART_VERSION != ''
         uses: aleoyakas/check-semver-increased-action@415c9c60054c2442c03478b6dd96a195deac6695 # v1
         id: check-version
         with:
@@ -74,7 +72,7 @@ jobs:
           previous-version: ${{ steps.chart_eval.outputs.CURRENT_CHART_VERSION }}
 
       - name: Fail if Helm Chart version isnt updated
-        if: steps.chart_eval.outputs.CURRENT_CHART_VERSION != '' && steps.check-version.outputs.is-version-increased != 'true'
+        if: steps.check-version.outputs.is-version-increased != 'true'
         run: |
           echo "Helm Chart Version wasnt updated"
           exit 1
@@ -99,7 +97,7 @@ jobs:
           rm -rf ./packaged-chart
 
       - name: Sign artifacts with Cosign
-        run: cosign sign --yes ghcr.io/stakater/charts/reloader-v2:${{ steps.new_chart_version.outputs.result }}
+        run: cosign sign --yes ghcr.io/stakater/charts/reloader:${{ steps.new_chart_version.outputs.result }}
 
       - name: Publish Helm chart to gh-pages
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
@@ -120,7 +118,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: false
-          CUSTOM_TAG: reloader-v2-chart-v${{ steps.new_chart_version.outputs.result }}
+          CUSTOM_TAG: chart-v${{ steps.new_chart_version.outputs.result }}
 
       - name: Notify Slack
         uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -3,7 +3,7 @@ name: Release Helm chart
 on:
   push:
     tags:
-      - "reloader-v2-chart-v*"
+      - "chart-v*"
 
 permissions:
   contents: write
@@ -22,11 +22,16 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
+          tag: ${{ github.ref_name }}
         run: |
+          # Mark prerelease chart versions (e.g. chart-v3.0.0-beta.1) so they
+          # don't show up as the repo's latest release.
+          prerelease=""
+          case "${tag#chart-v}" in *-*) prerelease="--prerelease" ;; esac
           gh release create "$tag" \
               --repo="$GITHUB_REPOSITORY" \
-              --title="Helm chart reloader-v2 ${tag#reloader-v2-chart-v}" \
+              --title="Helm chart reloader ${tag#chart-v}" \
+              $prerelease \
               --generate-notes
 
       - name: Notify Slack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,15 @@ jobs:
 
       - name: Get Tag from Github Ref
         id: generate_tag
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        run: |
+          RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          # A '-' marks a SemVer prerelease (e.g. v2.0.0-beta.1). Only stable
+          # releases are allowed to move the floating `v2` tag.
+          case "$RELEASE_VERSION" in
+            *-*) echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT ;;
+            *)   echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT ;;
+          esac
 
       - name: Create timestamp
         id: prep
@@ -149,6 +157,8 @@ jobs:
 
       # v2 branch: publish a floating `v2` tag instead of `latest` so v2
       # releases never overwrite the v1 `latest` tag used by plain manifests.
+      # Prereleases publish only their exact version, so `v2` always points at
+      # the newest stable v2 build and never at a beta.
       - name: Build and Push Docker Image to ghcr registry
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -158,7 +168,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm,linux/arm64
           tags: |
-            ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }},${{ env.GHCR_IMAGE_REPOSITORY }}:v2
+            ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.RELEASE_VERSION }}${{ steps.generate_tag.outputs.IS_PRERELEASE == 'false' && format(',{0}:v2', env.GHCR_IMAGE_REPOSITORY) || '' }}
           build-args: |
             VERSION=${{ steps.generate_tag.outputs.RELEASE_VERSION }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/reloader-enterprise-published.yml
+++ b/.github/workflows/reloader-enterprise-published.yml
@@ -9,6 +9,9 @@ permissions: {}
 
 jobs:
   dispatch:
+    # Skip prereleases (betas) and chart releases; only stable operator
+    # releases should trigger the enterprise build.
+    if: ${{ !github.event.release.prerelease && !startsWith(github.event.release.tag_name, 'chart-v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger target repository workflow

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,5 +27,9 @@ checksum:
 changelog:
   # It will be generated manually as part of making a new GitHub release
   disable: true
+release:
+  # Tags with a SemVer prerelease suffix (e.g. v2.0.0-beta.1) are published as
+  # GitHub prereleases so they never become the repo's "Latest" release.
+  prerelease: auto
 env_files:
   github_token: /home/jenkins/.apitoken/hub

--- a/deployments/kubernetes/chart/reloader/Chart.yaml
+++ b/deployments/kubernetes/chart/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: reloader-v2
+name: reloader
 description: Reloader chart that runs on kubernetes
-version: 2.0.0
-appVersion: v2.0.0
+version: 3.0.0-beta.1
+appVersion: v2.0.0-beta.1
 keywords:
   - Reloader
   - kubernetes

--- a/deployments/kubernetes/chart/reloader/README.md
+++ b/deployments/kubernetes/chart/reloader/README.md
@@ -4,19 +4,28 @@ If you have configured helm on your cluster, you can add Reloader to helm from o
 
 ## Installation
 
+> **Reloader v2 is currently a prerelease.** The commands below resolve to the
+> latest *stable* chart, which is still Reloader v1. To install the v2 beta you
+> must opt in explicitly, because Helm skips prerelease versions by default:
+>
+> ```bash
+> # --devel picks up the newest prerelease; add --version to pin a specific beta
+> helm install {{RELEASE_NAME}} stakater/reloader --devel
+> ```
+
 ```bash
 # Add stakater helm repoository
 helm repo add stakater https://stakater.github.io/stakater-charts
 
 helm repo update
 
-helm install stakater/reloader-v2 # For helm3 add --generate-name flag or set the release name
+helm install stakater/reloader # For helm3 add --generate-name flag or set the release name
 
-helm install {{RELEASE_NAME}} stakater/reloader-v2 -n {{NAMESPACE}} --set reloader.watchGlobally=false # By default, Reloader watches in all namespaces. To watch in single namespace, set watchGlobally=false
+helm install {{RELEASE_NAME}} stakater/reloader -n {{NAMESPACE}} --set reloader.watchGlobally=false # By default, Reloader watches in all namespaces. To watch in single namespace, set watchGlobally=false
 
-helm install stakater/reloader-v2 --set reloader.watchGlobally=false --namespace test --generate-name # Install Reloader in `test` namespace which will only watch `Deployments`, `Daemonsets` `Statefulsets` and `Rollouts` in `test` namespace.
+helm install stakater/reloader --set reloader.watchGlobally=false --namespace test --generate-name # Install Reloader in `test` namespace which will only watch `Deployments`, `Daemonsets` `Statefulsets` and `Rollouts` in `test` namespace.
 
-helm install stakater/reloader-v2 --set reloader.ignoreJobs=true --set reloader.ignoreCronJobs=true --generate-name # Install Reloader ignoring Jobs and CronJobs from reload monitoring
+helm install stakater/reloader --set reloader.ignoreJobs=true --set reloader.ignoreCronJobs=true --generate-name # Install Reloader ignoring Jobs and CronJobs from reload monitoring
 ```
 
 ## Uninstalling
@@ -39,7 +48,7 @@ helm uninstall {{RELEASE_NAME}} -n {{NAMESPACE}}
 | ------------------ | ---------------------------------------- | ------ | ----------------- |
 | `nameOverride`     | replace the name of the chart            | string | `""`              |
 | `fullnameOverride` | replace the generated name               | string | `""`              |
-| `image`            | Set container image name, tag and policy | map    | `see values.yaml` |
+| `image`            | Set container image name, tag and policy. `image.tag` defaults to the chart `appVersion` when empty | map    | `see values.yaml` |
 
 ### Core Reloader Parameters
 

--- a/deployments/kubernetes/chart/reloader/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/reloader/templates/deployment.yaml
@@ -80,13 +80,14 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+      {{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
       {{- if .Values.global.imageRegistry }}
-      - image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+      - image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.name }}:{{ $imageTag }}"
       {{- else }}
       {{- if .Values.image.digest }}
       - image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
       {{- else }}
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      - image: "{{ .Values.image.repository }}:{{ $imageTag }}"
       {{- end }}
       {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deployments/kubernetes/chart/reloader/tests/enterprise_test.yaml
+++ b/deployments/kubernetes/chart/reloader/tests/enterprise_test.yaml
@@ -2,21 +2,41 @@ suite: Enterprise image swap
 templates:
   - deployment.yaml
 tests:
+  # Tag is asserted by pattern, not literal, so a release bump does not churn tests.
   - it: uses the community image by default
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/stakater/reloader:v[0-9]+\.[0-9]+\.[0-9]+
+  # An empty image.tag must fall back to Chart.yaml appVersion, never render "repo:".
+  - it: falls back to the chart appVersion when image.tag is empty
+    set:
+      image:
+        tag: ""
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/stakater/reloader:v[0-9]+\.[0-9]+\.[0-9]+
+  - it: prefers an explicit image.tag over the chart appVersion
+    set:
+      image:
+        tag: pinned-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/stakater/reloader:v2.0.0
+          value: ghcr.io/stakater/reloader:pinned-tag
   # The operator image is swapped manually via image.*; enterprise.enabled only
   # toggles the subchart and must NOT change the operator image on its own.
   - it: enterprise.enabled alone does not change the operator image
     set:
       enterprise:
         enabled: true
+      image:
+        tag: pinned-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/stakater/reloader:v2.0.0
+          value: ghcr.io/stakater/reloader:pinned-tag
   - it: uses the enterprise image when the image block is overridden
     set:
       image:

--- a/deployments/kubernetes/chart/reloader/tests/namespaces_rbac_test.yaml
+++ b/deployments/kubernetes/chart/reloader/tests/namespaces_rbac_test.yaml
@@ -82,7 +82,7 @@ tests:
           of: RoleBinding
       - equal:
           path: roleRef.name
-          value: reloader-reloader-v2-role
+          value: reloader-reloader-role
       - equal:
           path: subjects[0].namespace
           value: reloader-ns
@@ -97,7 +97,7 @@ tests:
     template: role.yaml
     documentSelector:
       path: metadata.name
-      value: reloader-reloader-v2-metadata-role
+      value: reloader-reloader-metadata-role
     asserts:
       - equal:
           path: metadata.namespace
@@ -119,7 +119,7 @@ tests:
     template: role.yaml
     documentSelector:
       path: metadata.name
-      value: reloader-reloader-v2-metadata-role
+      value: reloader-reloader-metadata-role
     asserts:
       - contains:
           path: rules
@@ -143,7 +143,7 @@ tests:
     template: role.yaml
     documentSelector:
       path: metadata.name
-      value: reloader-reloader-v2-metadata-role
+      value: reloader-reloader-metadata-role
     asserts:
       - notContains:
           path: rules
@@ -194,7 +194,7 @@ tests:
         template: role.yaml
       - equal:
           path: metadata.name
-          value: reloader-reloader-v2-metadata-role
+          value: reloader-reloader-metadata-role
         template: role.yaml
         documentIndex: 0
 

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -24,7 +24,8 @@ fullnameOverride: ""
 image:
   name: stakater/reloader
   repository: ghcr.io/stakater/reloader
-  tag: v2.0.0
+  # Defaults to Chart.yaml appVersion, so a release only needs to bump appVersion.
+  tag: ""
   # digest: sha256:1234567
   pullPolicy: IfNotPresent
 

--- a/deployments/kubernetes/chart/reloader/values.yaml
+++ b/deployments/kubernetes/chart/reloader/values.yaml
@@ -10,10 +10,12 @@ global:
   #imagePullSecrets:
   #  - my-pull-secret
 
-  ## Required when enterprise.enabled=true (shared with the enterprise subchart)
-  consoleHost: ""
-  gatewayHost: ""
-  gatewayScheme: https
+  ## Required when enterprise.enabled=true (shared with the enterprise subchart).
+  ## The console and the gateway share this one hostname and are told apart by
+  ## path: console at /, gateway at gatewayBasePath.
+  host: ""
+  gatewayBasePath: /gateway
+  ingressScheme: https
 
 kubernetes:
   host: https://kubernetes.default

--- a/test/e2e/utils/helm.go
+++ b/test/e2e/utils/helm.go
@@ -207,10 +207,10 @@ func ReloaderDeploymentName(releaseName string) string {
 	if releaseName == "" {
 		releaseName = DefaultHelmReleaseName
 	}
-	// The chart is named "reloader-v2", so the fullname template renders
-	// <release>-reloader-v2. Keep this the single source of truth; the
+	// The chart is named "reloader", so the fullname template renders
+	// <release>-reloader. Keep this the single source of truth; the
 	// cluster-role and pod-selector helpers derive their names from it.
-	return releaseName + "-reloader-v2"
+	return releaseName + "-reloader"
 }
 
 // ReloaderPodSelector returns the label selector for Reloader pods.

--- a/test/e2e/utils/helm_test.go
+++ b/test/e2e/utils/helm_test.go
@@ -124,12 +124,12 @@ func TestReloaderDeploymentName(t *testing.T) {
 		{
 			name:        "default release name",
 			releaseName: "",
-			expected:    "reloader-reloader-v2",
+			expected:    "reloader-reloader",
 		},
 		{
 			name:        "custom release name",
 			releaseName: "my-reloader",
-			expected:    "my-reloader-reloader-v2",
+			expected:    "my-reloader-reloader",
 		},
 	}
 
@@ -152,12 +152,12 @@ func TestReloaderPodSelector(t *testing.T) {
 		{
 			name:        "default release name",
 			releaseName: "",
-			expected:    "app=reloader-reloader-v2",
+			expected:    "app=reloader-reloader",
 		},
 		{
 			name:        "custom release name",
 			releaseName: "my-reloader",
-			expected:    "app=my-reloader-reloader-v2",
+			expected:    "app=my-reloader-reloader",
 		},
 	}
 


### PR DESCRIPTION
## Publish v2 under the existing `reloader` chart as 3.0.0-beta.x

### Why

The v2 line was being published as a separate chart named `reloader-v2` at version 2.0.0. That forks the chart identity: users would end up with two unrelated charts in `stakater/reloader`, the chart version would no longer be comparable to the 2.2.x line already published, and every downstream reference (docs, RBAC names, e2e helpers, cosign, release tags) carries a name that only exists because v2 needed somewhere to live.

This keeps one chart name, `reloader`, and expresses the break the normal way instead: a major chart bump to 3.0.0, shipped as SemVer prereleases (`3.0.0-beta.1`) pointing at appVersion `v2.0.0-beta.1`. Helm skips prereleases by default, so existing v1 users on `stakater/reloader` are untouched until they explicitly opt in with `--devel`.

```bash
helm repo update
helm install reloader stakater/reloader           # still Reloader v1, chart 2.2.x
helm install reloader stakater/reloader --devel   # Reloader v2 beta, chart 3.0.0-beta.1
```

### What changed

**Chart identity**: `Chart.yaml` name back to `reloader`, version `3.0.0-beta.1`, appVersion `v2.0.0-beta.1`. Renders as `<release>-reloader`, so the e2e helm helpers and the RBAC name assertions in the chart tests follow.

**Prerelease plumbing**, so a beta never presents itself as the latest thing:

* `.goreleaser.yml` gets `prerelease: auto`, so a `v2.0.0-beta.1` tag publishes as a GitHub prerelease rather than the repo's Latest release
* the floating `v2` Docker tag is only pushed for stable releases, so `v2` always resolves to the newest stable v2 build
* chart releases created from a `chart-v3.0.0-beta.1` tag are marked `--prerelease`
* the enterprise dispatch skips prereleases and chart releases, so betas do not kick off enterprise builds

**Chart version gate**: `helm search repo` now passes `--devel`, otherwise the published prerelease is invisible to the gate and beta to beta bumps go unchecked. Also fixed the chart release workflow to use `github.ref_name`, since `github.ref` gave `gh release create` a full `refs/tags/...` ref and left the release title unstripped.

**One place to bump per release**: the image tag was duplicated across `values.yaml`, `Chart.yaml` appVersion, and two chart test assertions. `image.tag` now defaults to `.Chart.AppVersion` when empty, so a release bump is a single line in `Chart.yaml`. The digest path and explicit tag overrides are unchanged, and the chart tests assert the fallback rather than a literal version.

### Verification

`helm lint` clean, `helm unittest` 35/35, `go test ./test/e2e/utils/...` passing. Rendered and checked all five image paths: default, `global.imageRegistry`, explicit tag, digest, and the e2e style override.

### Note for release ordering

Chart 3.0.0-beta.1 defaults to `ghcr.io/stakater/reloader:v2.0.0-beta.1`, so the operator tag has to be pushed before this chart is published, otherwise a `--devel` install lands in ImagePullBackOff.
