### PR TITLE
chart: fix reloader-namespaceSelector helper comment

### DIFF
--- a/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
+++ b/deployments/kubernetes/chart/reloader/templates/_helpers.tpl
@@ -80,7 +80,8 @@ meta.helm.sh/release-name: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*
-Create the namespace selector if it does not watch globally
+Emit reloader.namespaceSelector when watching globally (label filter on namespaces).
+Only used when reloader.watchGlobally is true; see chart README / values comments.
 */}}
 {{- define "reloader-namespaceSelector" -}}
 {{- if and .Values.reloader.watchGlobally .Values.reloader.namespaceSelector -}}


### PR DESCRIPTION
The helper comment said it ran when *not* watching globally, but the `if` (and the chart README / values notes) only wire `--namespace-selector` when `watchGlobally` is true.

Left the condition alone; just aligned the comment so it stops looking like a logic bug.

Fixes #1188