### PR TITLE
fix: reject non-positive pause-period durations

### DIFF
--- a/internal/pkg/handler/pause_deployment.go
+++ b/internal/pkg/handler/pause_deployment.go
@@ -59,6 +59,11 @@ func ParsePauseDuration(pauseIntervalValue string) (time.Duration, error) {
 		logrus.Warnf("Failed to parse pause interval value '%s': %v", pauseIntervalValue, err)
 		return 0, err
 	}
+	if pauseDuration <= 0 {
+		err = fmt.Errorf("pause interval must be positive, got '%s'", pauseIntervalValue)
+		logrus.Warn(err)
+		return 0, err
+	}
 	return pauseDuration, nil
 }
 

--- a/internal/pkg/handler/pause_deployment_test.go
+++ b/internal/pkg/handler/pause_deployment_test.go
@@ -179,6 +179,18 @@ func TestParsePauseDuration(t *testing.T) {
 			expectedDuration:   0,
 			invalidDuration:    true,
 		},
+		{
+			name:               "zero duration",
+			pauseIntervalValue: "0s",
+			expectedDuration:   0,
+			invalidDuration:    true,
+		},
+		{
+			name:               "negative duration",
+			pauseIntervalValue: "-5m",
+			expectedDuration:   0,
+			invalidDuration:    true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`ParsePauseDuration` parsed the `pause-period` annotation with only `time.ParseDuration`, so `"0s"` or a negative value passed through. But the flag doc states *only positive values are allowed*, and downstream `CreateResumeTimer` uses `time.AfterFunc`, which fires **immediately** for a non-positive duration — so a non-positive `pause-period` silently degrades to *no pause at all*.

This rejects non-positive durations with a clear error and adds `"0s"`/`"-5m"` cases to `TestParsePauseDuration`.

Verified: `TestParsePauseDuration` passes with the fix; without it the new rows fail (a zero/negative value returns no error).

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
