### PR TITLE
chore: bump Go to 1.26.8 and spdystream to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stakater/Reloader
 
-go 1.26.4
+go 1.26.8
 
 require (
 	github.com/argoproj/argo-rollouts v1.9.0
@@ -174,7 +174,7 @@ require (
 	github.com/mgechev/revive v1.13.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Why

Pre-release check for v1.4.22 found reachable CVEs in the tagged code. `go.mod` pinned `go 1.26.4`, and every release/CI workflow resolves its toolchain with `go-version-file: 'go.mod'` — so builds were held on 1.26.4 and the shipped binary carried the vulnerable stdlib.

This is the same class of problem that blocked v1.4.20's enterprise build and forced a v1.4.21 respin, so it is worth clearing before tagging.

## What

- `go` directive: `1.26.4` → `1.26.8`
- `github.com/moby/spdystream` (indirect): `v0.5.0` → `v0.5.1`

Only `go.mod` and `go.sum` change, 4 lines each. `go mod tidy` produced no other churn.

## CVEs cleared

Reachable per `govulncheck`, fixed by the Go 1.26.8 toolchain:

| CVE | Severity | Package |
|---|---|---|
| CVE-2026-39821 | **critical** | `net/http` (x/net/idna) |
| CVE-2026-56862 | high | `crypto/tls` |
| CVE-2026-56853 | high | `net/http` |
| CVE-2026-33818 | high | `encoding/asn1` |
| CVE-2026-56860 | medium | `net/url` |
| CVE-2026-42505 | medium | `crypto/tls` |

Fixed by the spdystream bump:

| CVE | Severity | Package |
|---|---|---|
| CVE-2026-35469 | high (8.7) | `github.com/moby/spdystream` |

`spdystream` is only reachable from `test/e2e/utils/csi.go`, so it was never in the shipped binary; bumped for completeness.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `govulncheck ./...` — **0 reachable vulnerabilities** (was 7)
- `go test ./internal/... ./pkg/...` — all pass except `TestRunLeaderElectionWithControllers`, which fails identically on unmodified master in my environment (a Pod Security Admission label that CI's `make e2e-setup` provides). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)